### PR TITLE
Fix bug where pipeline wouldn't kick off on new builds

### DIFF
--- a/.github/workflows/deploy-to-dev.yaml
+++ b/.github/workflows/deploy-to-dev.yaml
@@ -4,8 +4,8 @@ on:
     paths:
       - 'react-frontend'
       - openshift/templates/react-frontend
-      - ansible/build-react.yaml
-      - ansible/deploy-react.yaml
+      - openshift/ansible/build-react.yaml
+      - openshift/ansible/deploy-react.yaml
 jobs:
   run:
     runs-on: ubuntu-18.04

--- a/.github/workflows/deploy-to-dev.yaml
+++ b/.github/workflows/deploy-to-dev.yaml
@@ -1,12 +1,11 @@
 name: Deploy React To Dev
-on: [pull_request]
-# on: 
-#   pull_request:
-#     paths:
-#       - 'react-frontend'
-#       - openshift/templates/react-frontend
-#       - ansible/build-react.yaml
-#       - ansible/deploy-react.yaml
+on: 
+  pull_request:
+    paths:
+      - 'react-frontend'
+      - openshift/templates/react-frontend
+      - ansible/build-react.yaml
+      - ansible/deploy-react.yaml
 jobs:
   run:
     runs-on: ubuntu-18.04

--- a/openshift/ansible/tasks/check_if_should_build.yaml
+++ b/openshift/ansible/tasks/check_if_should_build.yaml
@@ -31,13 +31,18 @@
       # if a build is cancelled the commit field is undefined inside of the build
       build_commit: "{% if build.resources[0].spec.revision is defined and build.resources[0].spec.revision.git.commit is defined  %}{{ build.resources[0].spec.revision.git.commit }}{% else %}''{% endif %}"
       build_phase: "{{ build.resources[0].status.phase }}"
+    when: bc.resources|length > 0
+
+    
 
   - name: Get last commit from PR {{ PR }}
     uri:
       url: https://api.github.com/repos/bcgov/digital.gov.bc.ca/commits/refs/pull/{{ PR }}/head
       method: GET
     register: response
-  
+    when: bc.resources|length > 0
+
   - name: Check if should build by comparing Build commit with PR Commit
     set_fact:
       should_build: "{% if response.json.sha == build_commit and build_phase != 'Cancelled'%}false{% else %}true{% endif %}"
+    when: bc.resources|length > 0


### PR DESCRIPTION
There was a bug in `check_if_should_build` script that would cause it to fail if a build didn't exist. This has been resolved.