### PR TITLE
bug-224 fixed wording in products/considering.js

### DIFF
--- a/react-frontend/src/components/products/considering.js
+++ b/react-frontend/src/components/products/considering.js
@@ -9,8 +9,9 @@ const cards = [
       connect with the{' '}
       <a
         className="productCardLink"
-        href="https://www2.gov.bc.ca/gov/content/overdose/mobile-response-team"
+        href="mailto:exchangelab@gov.bc.ca"
         target="_blank"
+        rel="noopener noreferrer"
       >
         Digital Response Unit
       </a>


### PR DESCRIPTION
First pull request on this project. Please let me know if I missed any steps. 

changed wording based on bug-224's suggestions. 

added "rel=noopener noreferrer" to correct eslint warning. Researched https://web.dev/external-anchors-use-rel-noopener/ and it doesn't seem to affect performance. Tested manually using npm start and clicking the link. 

I ran npm run cypress:test => failed on getting .pageHeader, however the page loads. 
![Cypress -- visits the app and checks for page title (failed)](https://user-images.githubusercontent.com/48116904/90323798-fcb3b180-df1a-11ea-8a4c-6b357abb1b50.png)
