### PR TITLE
adjust styling of "Skip to main content" link

### DIFF
--- a/react-frontend/src/components/Nav/navbar.js
+++ b/react-frontend/src/components/Nav/navbar.js
@@ -80,8 +80,8 @@ function NavBar() {
                 alt="Go to the Government of British Columbia website"
               />
             </NavBarHeaderLink>
-            <SkipToMainContent>Skip to main content</SkipToMainContent>
             <NavTitle>Digital Government</NavTitle>
+            <SkipToMainContent>Skip to main content</SkipToMainContent>
           </NavBanner>
           <NavContentOnRight>
             <div className="nav-btn" onClick={toggleMenu} href=".">

--- a/react-frontend/src/components/StyleComponents/nav.js
+++ b/react-frontend/src/components/StyleComponents/nav.js
@@ -100,15 +100,21 @@ export const SkipToMainContent = styled.a.attrs({
   href: '#main-content-anchor',
   'aria-label': 'Skip to main content',
 })`
-  position: absolute;
-  left: -10000px;
+  margin: 5px 0 0 -5000px;
+  padding: 0 5px;
   width: 120px;
   color: #fcba19;
+  text-decoration: underline;
+  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
   :hover {
     color: #fcba19;
+    text-decoration: underline;
   }
   :focus {
-    position: static;
-    height: auto;
+    margin-left: 5px;
+    text-decoration: underline;
+    outline: 5px auto -webkit-focus-ring-color;
   }
 `;


### PR DESCRIPTION
Adjusted styling to match gov.bc.ca:

![image](https://user-images.githubusercontent.com/16946297/94957272-53148980-04a2-11eb-8d58-94e82b6b7dea.png)

Here's how it looks in **accessibility-240**:

![accessibility-240](https://user-images.githubusercontent.com/16946297/94957106-1183de80-04a2-11eb-8d0a-9d098317427f.png)

Here's how it looks in **mw-accessibility-240**:

![mw-accessibility-240](https://user-images.githubusercontent.com/16946297/94957121-16e12900-04a2-11eb-8f1d-957ffa0c2425.png)
