### PR TITLE
clean up inconsistent link styles #279

### DIFF
--- a/react-frontend/src/components/StyleComponents/pageContent.js
+++ b/react-frontend/src/components/StyleComponents/pageContent.js
@@ -11,6 +11,7 @@ export const GlobaStyleSize = createGlobalStyle`
 export const SimpleTextContainer = styled.div`
   padding-top: 120px;
   font-size: 2rem;
+  font-family: BC Sans;
   max-width: 80rem;
   margin-right: auto;
   margin-left: auto;

--- a/react-frontend/src/css/card.css
+++ b/react-frontend/src/css/card.css
@@ -1,121 +1,118 @@
 /* TODO: Finish migrating this to the card.js styled components */
 
 .cardBody {
-    font-size: 16pt;
-    margin-bottom: 20px;
-    width: 330px;
+  font-size: 16pt;
+  margin-bottom: 20px;
+  width: 330px;
 }
 
 .cardBodyHorizontal {
-    height: 330px;
-    margin-bottom: 20px;
+  height: 330px;
+  margin-bottom: 20px;
 }
 
 .cardImage {
-    height: auto;
-    max-width: 100%;
-    min-height: 330px;
-    min-width: 100%;
+  height: auto;
+  max-width: 100%;
+  min-height: 330px;
+  min-width: 100%;
 }
 
 .cardImageContainer {
-    height: 330px;
-    overflow: hidden;
+  height: 330px;
+  overflow: hidden;
 }
 
 .cardImageContainerHorizontal {
-    float: left;
-    margin-right: 25px;
-    overflow: hidden;
-    width: 50%;
+  float: left;
+  margin-right: 25px;
+  overflow: hidden;
+  width: 50%;
 }
 
 .cardImageHorizontal {
-    float: left;
-    height: auto;
-    margin-right: 30px;
-    max-width: 110%;
-    width: auto;
+  float: left;
+  height: auto;
+  margin-right: 30px;
+  max-width: 110%;
+  width: auto;
 }
 
 .cardLink {
-    bottom: 25px;
-    color: #1a5a96;
-    font-family: 'BC Sans';
-    font-size: 16px;
-    font-weight: bold;
-    position: absolute;
-    text-decoration: underline;
+  bottom: 25px;
+  color: #1a5a96;
+  font-family: 'BC Sans';
+  font-size: 16px;
+  font-weight: bold;
+  position: absolute;
+  text-decoration: underline;
 }
 
 .cardLink:hover {
-    color: blue;
-    text-decoration: none;
+  color: blue;
+  text-decoration: none;
 }
 
 .cardLinkHorizontal {
-    bottom: 20px;
-    color: #1a5a96;
-    font-family: 'BC Sans';
-    font-size: 16px;
-    font-weight: bold;
-    text-decoration: underline;
+  bottom: 20px;
+  color: #1a5a96;
+  font-family: 'BC Sans';
+  font-size: 16px;
+  font-weight: bold;
 }
 
 .cardText {
-    padding: 16px;
-    text-align: left;
+  padding: 16px;
+  text-align: left;
 }
 
 .cardTextHorizontal {
-    padding: 16px;
-    text-align: left;
+  padding: 16px;
+  text-align: left;
 }
 
 .overFlowHidden {
-    overflow: hidden;
+  overflow: hidden;
 }
 
 @media only screen and (max-width: 800px) {
-    .cardBody {
-        height: 95%;
-        width: 330px;
-    }
+  .cardBody {
+    height: 95%;
+    width: 330px;
+  }
 
-    .cardBodyHorizontal {
-        height: 95%;
-        width: 330px;
-    }
+  .cardBodyHorizontal {
+    height: 95%;
+    width: 330px;
+  }
 
-    .cardImage {
-        height: 330px;
-        margin-left: -45%;
-        max-width: none;
-        width: auto;
-    }
+  .cardImage {
+    height: 330px;
+    margin-left: -45%;
+    max-width: none;
+    width: auto;
+  }
 
-    .cardImageContainer {
-        max-height: 330px;
-    }
+  .cardImageContainer {
+    max-height: 330px;
+  }
 
-    .cardImageContainerHorizontal {
-        overflow: hidden;
-        width: 100%;
-    }
+  .cardImageContainerHorizontal {
+    overflow: hidden;
+    width: 100%;
+  }
 
-    .cardImageHorizontal {
-        height: auto;
-        max-width: 100%;
-        margin-right: 0;
-    }
+  .cardImageHorizontal {
+    height: auto;
+    max-width: 100%;
+    margin-right: 0;
+  }
 
-    .cardLink {
-        bottom: 20px;
-    }
+  .cardLink {
+    bottom: 20px;
+  }
 
-    .cardLinkHorizontal {
-        bottom: 10px;
-    }
-
-   
+  .cardLinkHorizontal {
+    bottom: 10px;
+  }
 }

--- a/react-frontend/src/css/casetemplates.css
+++ b/react-frontend/src/css/casetemplates.css
@@ -1,28 +1,25 @@
 .pageBody {
-    margin: auto;
-    width: 1124px;
+  margin: auto;
+  width: 1124px;
 }
 
 .resourceLink {
-    font-size: 20px;
-    padding-top: 20px;
-    text-decoration: underline;
+  font-size: 20px;
+  padding-top: 20px;
 }
 
 .resourceLinkBox {
-    margin-bottom: 20px;
-    margin-top: -20px;
+  margin-bottom: 20px;
+  margin-top: -20px;
 }
 
 @media only screen and (max-width: 800px) {
+  .cardAdjustment {
+    margin-left: -8px;
+    margin-right: -8px;
+  }
 
-    .cardAdjustment {
-        margin-left: -8px;
-        margin-right: -8px;
-    }
-
-    .pageBody {
-        width: 330px;
-    }
+  .pageBody {
+    width: 330px;
+  }
 }
-

--- a/react-frontend/src/css/digital.css
+++ b/react-frontend/src/css/digital.css
@@ -1,142 +1,139 @@
 .contentRow {
-    border-bottom: solid thin black;
-    padding-bottom: 25px;
-    padding-top: 20px;
+  border-bottom: solid thin black;
+  padding-bottom: 25px;
+  padding-top: 20px;
 }
 
 .digitalBlock {
-    margin-bottom: 25px;
+  margin-bottom: 25px;
 }
 
 .digitalBody {
-    width: 960px;
-    margin: auto;
+  width: 960px;
+  margin: auto;
 }
 
 .digitalContainer {
-    background-color: #F2F2F2;
-    padding-bottom: 70px;
-    padding-top: 100px;
+  background-color: #f2f2f2;
+  padding-bottom: 70px;
+  padding-top: 100px;
 }
 
 .digitalLink {
-    color: #0000EE;
-    cursor: pointer;
-    font-size: 12pt;
-    font-weight: bold;
+  cursor: pointer;
+  font-size: 12pt;
+  font-weight: bold;
 }
 
 .digitalParagraph {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 16px;
-    line-height: 24px;
-    position: relative;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 16px;
+  line-height: 24px;
+  position: relative;
 }
 
 .digitalPageText {
-    margin: auto;
-    padding-bottom: 110px;
-    padding-top: 120px;
-    text-align: center;
-    width: 975px;
+  margin: auto;
+  padding-bottom: 110px;
+  padding-top: 120px;
+  text-align: center;
+  width: 975px;
 }
 
 .digitalSection {
-    padding-bottom: 60px;
+  padding-bottom: 60px;
 }
 
 .digitalTable {
-    margin-left: -8px;
+  margin-left: -8px;
 }
 
 .digitalTableTitle {
-    font-size: 16pt;
-    font-weight: bold;
-    line-height: 24pt;
-    margin-bottom: 5px;
-    margin-top: 5px;
+  font-size: 16pt;
+  font-weight: bold;
+  line-height: 24pt;
+  margin-bottom: 5px;
+  margin-top: 5px;
 }
 
 .tableSpacer {
-    padding-top: 60px;
+  padding-top: 60px;
 }
 
 .digitalTitle {
-    font-size: 22pt;
-    font-weight: bold;
-    line-height: 24pt;
-    margin-bottom: 5px;
+  font-size: 22pt;
+  font-weight: bold;
+  line-height: 24pt;
+  margin-bottom: 5px;
 }
 
 .firstRow {
-    border-bottom: solid darkgray;
+  border-bottom: solid darkgray;
 }
 
 .lastRow {
-    height: 80px;
-    margin-bottom: 25px;
-    padding-top: 20px;
+  height: 80px;
+  margin-bottom: 25px;
+  padding-top: 20px;
 }
 
 @media only screen and (max-width: 1200px) {
-    .digitalBody {
-        width: 85%;
-    }
-    .someLinks {
-        margin-top: -15px;
-    }
+  .digitalBody {
+    width: 85%;
+  }
+  .someLinks {
+    margin-top: -15px;
+  }
 }
 
 @media only screen and (max-width: 800px) {
+  .contentRow {
+    padding-top: 15px;
+  }
 
-    .contentRow {
-        padding-top: 15px;
-    }
+  .digitalBlock {
+    margin-bottom: 25px;
+  }
 
-    .digitalBlock {
-        margin-bottom: 25px;
-    }
+  .digitalBody {
+    width: 85%;
+  }
 
-    .digitalBody {
-        width: 85%;
-    }
-    
-    .digitalContainer {
-        padding-top: 65px;
-    }
+  .digitalContainer {
+    padding-top: 65px;
+  }
 
-    .digitalPageText {
-        margin-left: 8%;
-        padding-bottom: 80px;
-        padding-top: 140px;
-        width: 84%;
-    }
+  .digitalPageText {
+    margin-left: 8%;
+    padding-bottom: 80px;
+    padding-top: 140px;
+    width: 84%;
+  }
 
-    .digitalSection {
-        padding-bottom: 60px;
-    }
+  .digitalSection {
+    padding-bottom: 60px;
+  }
 
-    .digitalTable {
-        margin-bottom: 100px;
-    }
+  .digitalTable {
+    margin-bottom: 100px;
+  }
 
-    .digitalTop {
-        padding-top: 60px;
-    }
+  .digitalTop {
+    padding-top: 60px;
+  }
 
-    .lastRow {
-        height: 200px;
-        padding-top: 20px;
-    }    
-
+  .lastRow {
+    height: 200px;
+    padding-top: 20px;
+  }
 }
 
 @media only screen and (max-width: 400px) {
-    .digitalBlock {
-        margin-bottom: 40px;
-    }
+  .digitalBlock {
+    margin-bottom: 40px;
+  }
 
-    .digitalTable {
-        margin-bottom: 150px;
-    }
+  .digitalTable {
+    margin-bottom: 150px;
+  }
 }

--- a/react-frontend/src/css/global.css
+++ b/react-frontend/src/css/global.css
@@ -1,7 +1,9 @@
 a {
   color: #1a5a96;
+  text-decoration: underline;
 }
 
-a:hover{
+a:hover {
   color: blue;
+  text-decoration: none;
 }


### PR DESCRIPTION
Fixed link styles according to https://github.com/bcgov/digital.gov.bc.ca/issues/279. I went through each task and attached a gif to show that it works. I went overboard playing with some new capture software :) 

*note - header and footer links are not underlined until hovered. This seems to be the intended effect and my changes do not affect this. 
![Header 2020-10-05 at 00 42 39](https://user-images.githubusercontent.com/48116904/95053296-15cc1980-06a5-11eb-9b01-48e612ee6185.gif)

Links on white cards
![White Card 2020-10-05 at 00 43 20](https://user-images.githubusercontent.com/48116904/95053317-1c5a9100-06a5-11eb-88f2-d7da742a0823.gif)

 Links under Our Priorities on the Digital Framework page
![Our Priorities 2020-10-05 at 00 44 35](https://user-images.githubusercontent.com/48116904/95053335-2086ae80-06a5-11eb-82cb-421b92bc72d3.gif)

 Inline links on the Digital Principles page
![Digital Principles 2020-10-05 at 00 45 27](https://user-images.githubusercontent.com/48116904/95053351-267c8f80-06a5-11eb-8ad9-9f81a768cc58.gif)

 Standalone links (under Technical, Privacy, Security, and For Designers headings) on the Resources page.
![Tec Pri Sec 2020-10-05 at 00 46 10](https://user-images.githubusercontent.com/48116904/95053371-2d0b0700-06a5-11eb-85d5-4e2c1e7e3287.gif)

Linked headings under Video Communication Options heading on the Video Communication Platforms page. (Please note also: these headings are not picking up font-family: 'BC Sans'.)

-BC Sans is now applied. Proof shown at the end of the gif. 
![Video Options 2020-10-05 at 00 50 56](https://user-images.githubusercontent.com/48116904/95053387-32685180-06a5-11eb-9dd8-5ef9ebd481d9.gif)

Suggestion: If we can, let's do away with all the individual classes for links (e.g. productCardLink, resourceLink, etc.)

I did not refractor these out because I was unsure how that would affect the website functionality. 