### PR TITLE
tweak footer styles

### DIFF
--- a/react-frontend/src/components/Nav/footer.js
+++ b/react-frontend/src/components/Nav/footer.js
@@ -4,6 +4,7 @@ import { FooterStyled, FooterContainer } from '../StyleComponents/pageContent';
 import {
   FooterLink,
   FooterLinkInternal,
+  FooterListItem,
   FooterUL,
 } from '../StyleComponents/htmlTags';
 
@@ -12,10 +13,10 @@ const Footer = () => {
     <FooterStyled>
       <FooterContainer>
         <FooterUL>
-          <li>
+          <FooterListItem>
             <FooterLinkInternal to="/">Home</FooterLinkInternal>
-          </li>
-          <li>
+          </FooterListItem>
+          <FooterListItem>
             <FooterLink
               href="https://www2.gov.bc.ca/gov/content/home/disclaimer"
               target="_blank"
@@ -23,8 +24,8 @@ const Footer = () => {
             >
               Disclaimer
             </FooterLink>
-          </li>
-          <li>
+          </FooterListItem>
+          <FooterListItem>
             <FooterLink
               href="https://www2.gov.bc.ca/gov/content/home/privacy"
               target="_blank"
@@ -32,8 +33,8 @@ const Footer = () => {
             >
               Privacy
             </FooterLink>
-          </li>
-          <li>
+          </FooterListItem>
+          <FooterListItem>
             <FooterLink
               href="https://www2.gov.bc.ca/gov/content/home/accessible-government"
               target="_blank"
@@ -41,8 +42,8 @@ const Footer = () => {
             >
               Accessibility
             </FooterLink>
-          </li>
-          <li>
+          </FooterListItem>
+          <FooterListItem>
             <FooterLink
               href="https://www2.gov.bc.ca/gov/content/home/copyright"
               target="_blank"
@@ -50,8 +51,8 @@ const Footer = () => {
             >
               Copyright
             </FooterLink>
-          </li>
-          <li>
+          </FooterListItem>
+          <FooterListItem>
             <FooterLink
               href="https://www2.gov.bc.ca/gov/content/home/get-help-with-government-services"
               target="_blank"
@@ -59,7 +60,7 @@ const Footer = () => {
             >
               Contact Us
             </FooterLink>
-          </li>
+          </FooterListItem>
         </FooterUL>
       </FooterContainer>
     </FooterStyled>

--- a/react-frontend/src/components/StyleComponents/htmlTags.js
+++ b/react-frontend/src/components/StyleComponents/htmlTags.js
@@ -26,11 +26,28 @@ export const BreadcrumbUL = styled.ul`
 export const FooterLink = styled.a.attrs({
   className: 'internalLink',
 })`
-  border-right: 1px solid #4b5e7e;
   color: #fff;
   font-size: 14px;
-  padding-left: 25px;
-  padding-right: 25px;
+  padding: 0 4px;
+  :hover {
+    color: white;
+    text-decoration: underline;
+  }
+  :focus {
+    outline-offset: 1px;
+    outline: 4px solid #3b99fc;
+  }
+  @media only screen and (max-width: 900px) {
+    font-size: 12px;
+  }
+`;
+
+export const FooterLinkInternal = styled(Link).attrs({
+  className: 'internalLink',
+})`
+  color: #fff;
+  font-size: 14px;
+  padding: 0 4px;
   :hover {
     color: white;
     text-decoration: underline;
@@ -46,27 +63,12 @@ export const FooterLink = styled.a.attrs({
   }
 `;
 
-export const FooterLinkInternal = styled(Link).attrs({
-  className: 'internalLink',
-})`
+export const FooterListItem = styled.li`
+  align-items: center;
   border-right: 1px solid #4b5e7e;
-  color: #fff;
-  font-size: 14px;
-  padding-left: 25px;
-  padding-right: 25px;
-  :hover {
-    color: white;
-    text-decoration: underline;
-  }
-  :focus {
-    outline-offset: 1px;
-    outline: 4px solid #3b99fc;
-  }
-  @media only screen and (max-width: 900px) {
-    font-size: 12px;
-    padding-left: 5px;
-    padding-right: 5px;
-  }
+  display: flex;
+  padding: 0 9px;
+  text-align: center;
 `;
 
 export const FooterUL = styled.ul`
@@ -77,7 +79,8 @@ export const FooterUL = styled.ul`
   flex-wrap: wrap;
   height: 100%;
   list-style: none;
-  margin: 0;
+  margin: 10px 0;
+  padding-left: 0 !important; /* cancels default padding-inline-start for unordered lists */
 `;
 
 export const HrefLink = styled.a.attrs({

--- a/react-frontend/src/components/StyleComponents/pageContent.js
+++ b/react-frontend/src/components/StyleComponents/pageContent.js
@@ -29,12 +29,14 @@ export const FooterContainer = styled.div.attrs({
   className: 'footerContainer',
 })`
   display: flex;
-  flex-direction: column;
-  height: 46px;
-  justify-content: center;
-  text-align: center;
-  @media only screen and (max-width: 900px) {
-    height: 70px;
+  max-width: 1115px; /* keeps footer inline with navbar; remove this and the padding styles below when we refactor containers */
+  padding-left: 30px;
+  @media screen and (min-width: 800px) {
+    padding-left: 107px;
+  }
+
+  @media screen and (max-width: 800px) {
+    padding-left: 15px;
   }
 `;
 


### PR DESCRIPTION
This PR tweaks some of the styling on #384 to make it conform better to the Design System (DevHub):
- distributed padding differently between the `<a>` and the `<li>` so that only the **text** of the link is clickable (not also the space around it)
- copied styling from `<NavBarContainer>` into `<footerContainer>` to keep the footer left-aligned with the navbar
- removed fixed `height` properties from `<footerContainer>` and added padding/margins to other elements to prevent over-padding of the footer, for example:
![image](https://user-images.githubusercontent.com/16946297/97212402-9a2e2b80-177d-11eb-92b0-d38a396b1a4f.png)
