### PR TITLE
tweak banner text styles

### DIFF
--- a/react-frontend/src/components/StyleComponents/bannerSimple.js
+++ b/react-frontend/src/components/StyleComponents/bannerSimple.js
@@ -4,14 +4,13 @@ export const BannerSubTitle = styled.p.attrs({
   className: 'bannerSubTitle',
 })`
   color: #313132;
+  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 22px;
-  position: relative;
+  margin: auto;
+  max-width: 800px;
   @media only screen and (max-width: 800px) {
-    font-size: 10pt;
-    text-align: justify;
     font-size: 16px;
     text-align: center;
-    width: 100%;
   }
 `;
 
@@ -45,11 +44,11 @@ export const BannerTitle = styled.h1.attrs({
   className: 'bannerTitle',
 })`
   color: #313132;
+  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 37px;
   font-weight: bold;
-  line-height: 37px;
+  line-height: 1.2;
   margin-bottom: 10px;
-  position: relative;
   text-align: center;
   @media only screen and (max-width: 800px) {
     font-size: 31px;

--- a/react-frontend/src/components/StyleComponents/bannerWithImage.js
+++ b/react-frontend/src/components/StyleComponents/bannerWithImage.js
@@ -18,19 +18,18 @@ export const BannerImage = styled.img.attrs({
 export const BannerSubTitle = styled.div.attrs({
   className: 'bannerSubTitle',
 })`
+  margin: auto;
+  max-width: 800px;
   p {
     color: white;
+    font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
     font-size: 22px;
-    position: relative;
+    text-align: center;
   }
 
   @media only screen and (max-width: 800px) {
-    font-size: 10pt;
-    text-align: justify;
     p {
       font-size: 16px;
-      text-align: center;
-      width: 100%;
     }
   }
 `;
@@ -69,11 +68,11 @@ export const BannerTitle = styled.h1.attrs({
   className: 'bannerTitle',
 })`
   color: white;
+  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 37px;
   font-weight: bold;
-  line-height: 37px;
+  line-height: 1.2;
   margin-bottom: 10px;
-  position: relative;
   text-align: center;
   @media only screen and (max-width: 800px) {
     font-size: 31px;
@@ -103,11 +102,11 @@ export const BannerSideImgTitle = styled.h1.attrs({
   className: 'bannerTitle',
 })`
   color: #313132;
+  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 37px;
   font-weight: bold;
-  line-height: 37px;
+  line-height: 1.2;
   margin-bottom: 10px;
-  position: relative;
   text-align: left;
   @media only screen and (max-width: 800px) {
     font-size: 31px;
@@ -118,7 +117,9 @@ export const BannerSideImgTitle = styled.h1.attrs({
 export const BannerSideImgSubTitle = styled.div.attrs({
   className: 'subTitle',
 })`
+  color: #313132;
   font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-size: 19px;
   text-align: left;
   @media only screen and (max-width: 800px) {
     text-align: center;


### PR DESCRIPTION
This PR is a tweak of #383 to add some missing styles to the new `<BannerSideImageTitle>` and `<BannerSideImageSubTitle>`. 

While I was at it, I checked the rest of the banner text styles and tweaked some styles to ensure consistency across the **three** banner patterns we have now:
- ensured the full `font-family` style was defined for all titles and subtitles (notice the titles are bolder now)
- put a `max-width` on bannerSubTitles to improve readability for long subtitles
- removed some unnecessary styles (e.g. `width: 100%`, `position: relative`, `text-align: justify`)
