### PR TITLE
fix display of images on bannerWithImage

### DIFF
--- a/react-frontend/src/components/PageElements/BannerWithImage/bannerWithImage.js
+++ b/react-frontend/src/components/PageElements/BannerWithImage/bannerWithImage.js
@@ -11,8 +11,7 @@ import {
 
 const BannerWithImage = ({ content, image, title }) => {
   return (
-    <BannerWithImageWrapper>
-      <BannerImage alt="" src={image} />
+    <BannerWithImageWrapper backgroundImage={image}>
       <BannerTextWrapper>
         <BannerText>
           <BannerTitle>{title}</BannerTitle>

--- a/react-frontend/src/components/StyleComponents/bannerWithImage.js
+++ b/react-frontend/src/components/StyleComponents/bannerWithImage.js
@@ -130,6 +130,9 @@ export const BannerSideImgSubTitle = styled.div.attrs({
 export const BannerWithImageWrapper = styled.div.attrs({
   className: 'banner',
 })`
+  background-image: url(${(props) => props.backgroundImage});
+  background-position: center center;
+  background-size: cover;
   height: 600px;
   margin-bottom: 120px;
   overflow: hidden;


### PR DESCRIPTION
This smaller PR is to replace #376. 

- Passed the image into the `background-image` property of the `<BannerTextWrapper>` so it's easier to control how the image displays.

(Mostly) fixes #375 