### PR TITLE
add Case Studies to nav

### DIFF
--- a/react-frontend/src/components/Nav/navbar.js
+++ b/react-frontend/src/components/Nav/navbar.js
@@ -142,16 +142,6 @@ function NavBar() {
                 Case Studies
               </NavBarLink>
             </NavBarLi>
-            <NavBarLi>
-              <NavBarLink
-                to="/marketplace"
-                className={
-                  activePage === '/marketplace' ? 'active' : 'notactive'
-                }
-              >
-                Marketplace
-              </NavBarLink>
-            </NavBarLi>
           </NavBarUl>
         </NavBarContainer>
       </NavMain>

--- a/react-frontend/src/components/Nav/navbar.js
+++ b/react-frontend/src/components/Nav/navbar.js
@@ -132,6 +132,26 @@ function NavBar() {
                 Products & Services
               </NavBarLink>
             </NavBarLi>
+            <NavBarLi>
+              <NavBarLink
+                to="/case-studies"
+                className={
+                  activePage === '/case-studies' ? 'active' : 'notactive'
+                }
+              >
+                Case Studies
+              </NavBarLink>
+            </NavBarLi>
+            <NavBarLi>
+              <NavBarLink
+                to="/marketplace"
+                className={
+                  activePage === '/marketplace' ? 'active' : 'notactive'
+                }
+              >
+                Marketplace
+              </NavBarLink>
+            </NavBarLi>
           </NavBarUl>
         </NavBarContainer>
       </NavMain>


### PR DESCRIPTION
Adds a link to the Case Studies page in the navbar.

Fixes #390

Note:
We also want a link to the Marketplace app in the navbar (see #424).
