### PR TITLE
Improvements for feature-359-grid

### DIFF
--- a/react-frontend/src/components/Nav/navbar.js
+++ b/react-frontend/src/components/Nav/navbar.js
@@ -104,34 +104,42 @@ function NavBar() {
       </NavBarHeader>
       <NavMain>
         <NavBarContainer>
-          <NavBarUl>
-            <NavBarLi>
-              <NavBarLinkFirst
-                to="/"
-                className={activePage === '/' ? 'active' : 'notactive'}
-              >
-                Home
-              </NavBarLinkFirst>
-            </NavBarLi>
-            <NavBarLi>
-              <NavBarLink
-                to="/resources"
-                className={activePage === '/resources' ? 'active' : 'notactive'}
-              >
-                Resources
-              </NavBarLink>
-            </NavBarLi>
-            <NavBarLi>
-              <NavBarLink
-                to="/products-services"
-                className={
-                  activePage === '/products-services' ? 'active' : 'notactive'
-                }
-              >
-                Products & Services
-              </NavBarLink>
-            </NavBarLi>
-          </NavBarUl>
+          <Row>
+            <Col xs={12}>
+              <NavBarUl>
+                <NavBarLi>
+                  <NavBarLinkFirst
+                    to="/"
+                    className={activePage === '/' ? 'active' : 'notactive'}
+                  >
+                    Home
+                  </NavBarLinkFirst>
+                </NavBarLi>
+                <NavBarLi>
+                  <NavBarLink
+                    to="/resources"
+                    className={
+                      activePage === '/resources' ? 'active' : 'notactive'
+                    }
+                  >
+                    Resources
+                  </NavBarLink>
+                </NavBarLi>
+                <NavBarLi>
+                  <NavBarLink
+                    to="/products-services"
+                    className={
+                      activePage === '/products-services'
+                        ? 'active'
+                        : 'notactive'
+                    }
+                  >
+                    Products & Services
+                  </NavBarLink>
+                </NavBarLi>
+              </NavBarUl>
+            </Col>
+          </Row>
         </NavBarContainer>
       </NavMain>
     </NavBarWrapper>

--- a/react-frontend/src/components/Resources/fordesigners.js
+++ b/react-frontend/src/components/Resources/fordesigners.js
@@ -16,10 +16,10 @@ function ForDesigners() {
     <ContentBlockContainer id="forDesigners">
       <Row>
         <Col sm={12}>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <ResourcePageSubHeading>For Designers</ResourcePageSubHeading>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -28,7 +28,7 @@ function ForDesigners() {
               B.C. Visual Identity Program (Gov Mark) {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -37,7 +37,7 @@ function ForDesigners() {
               CMS Lite User's Manual {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -46,7 +46,7 @@ function ForDesigners() {
               Content Design Guide {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -55,7 +55,7 @@ function ForDesigners() {
               Design Research Guide {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -64,7 +64,7 @@ function ForDesigners() {
               Design System {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -73,7 +73,7 @@ function ForDesigners() {
               Plain Language Guide {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -82,7 +82,7 @@ function ForDesigners() {
               Service Design Phases {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -91,7 +91,7 @@ function ForDesigners() {
               Service Writing Guide {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -100,7 +100,7 @@ function ForDesigners() {
               Visual Design Guide {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"

--- a/react-frontend/src/components/Resources/standards.js
+++ b/react-frontend/src/components/Resources/standards.js
@@ -15,10 +15,10 @@ function Standards() {
     <ContentBlockContainer id="standards">
       <Row>
         <Col md={12} lg={4}>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <ResourcePageSubHeading>Technical</ResourcePageSubHeading>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -28,7 +28,7 @@ function Standards() {
               {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -38,7 +38,7 @@ function Standards() {
               {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -50,10 +50,10 @@ function Standards() {
           </Row>
         </Col>
         <Col md={12} lg={4}>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <ResourcePageSubHeading>Privacy</ResourcePageSubHeading>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -63,7 +63,7 @@ function Standards() {
               {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -73,7 +73,7 @@ function Standards() {
               {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -85,10 +85,10 @@ function Standards() {
           </Row>
         </Col>
         <Col md={12} lg={4}>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <ResourcePageSubHeading>Security</ResourcePageSubHeading>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"
@@ -98,7 +98,7 @@ function Standards() {
               {linkIcon}
             </HrefLinkStandalone>
           </Row>
-          <Row>
+          <Row style={{ marginLeft: '0px', marginRight: '16px' }}>
             <HrefLinkStandalone
               target="_blank"
               rel="noopener noreferrer"

--- a/react-frontend/src/components/StyleComponents/headings.js
+++ b/react-frontend/src/components/StyleComponents/headings.js
@@ -62,7 +62,6 @@ export const ResourcePageSubHeading = styled.h3.attrs({
 `;
 
 export const SimpleTextPageTitle = styled.h1`
-  padding-top: 200px;
   font-size: 3rem;
   font-weight: 700;
   margin-top: 30px;

--- a/react-frontend/src/components/StyleComponents/htmlTags.js
+++ b/react-frontend/src/components/StyleComponents/htmlTags.js
@@ -125,6 +125,7 @@ export const FooterUL = styled.ul`
   flex-wrap: wrap;
   height: 46px; /* from Design System */
   list-style: none;
+  margin: 0;
   padding-left: 0 !important; /* cancels default padding-inline-start for unordered lists */
 `;
 

--- a/react-frontend/src/components/StyleComponents/htmlTags.js
+++ b/react-frontend/src/components/StyleComponents/htmlTags.js
@@ -21,7 +21,7 @@ export const BreadcrumbUL = styled.ul`
   display: flex;
   flex-direction: row;
   list-style: none;
-  margin: 0;
+  margin: 0 0 0 -8px; /* negative left margin aligns breadcrumb with page elements */
   padding-left: 0;
   padding-top: 16px;
 `;
@@ -123,9 +123,8 @@ export const FooterUL = styled.ul`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  height: 100%;
+  height: 46px; /* from Design System */
   list-style: none;
-  margin: 10px 0;
   padding-left: 0 !important; /* cancels default padding-inline-start for unordered lists */
 `;
 

--- a/react-frontend/src/components/StyleComponents/pageContent.js
+++ b/react-frontend/src/components/StyleComponents/pageContent.js
@@ -42,6 +42,7 @@ const HorizontalContainer = styled(Grid).attrs({
   className: 'horizontalAlignment',
 })`
   margin: auto;
+  padding: 0 16px;
   @media screen and (min-width: 576px) {
     width: 540px;
   }

--- a/react-frontend/src/components/StyleComponents/pageContent.js
+++ b/react-frontend/src/components/StyleComponents/pageContent.js
@@ -42,15 +42,17 @@ const HorizontalContainer = styled(Grid).attrs({
   className: 'horizontalAlignment',
 })`
   margin: auto;
-  max-width: 1065px;
-  padding-left: 30px;
-  padding-right: 20px;
-  z-index: -2;
-  @media screen and (min-width: 800px) {
-    padding-left: 107px;
+  @media screen and (min-width: 576px) {
+    width: 540px;
   }
-  @media screen and (max-width: 800px) {
-    padding-left: 15px;
+  @media screen and (min-width: 768px) {
+    width: 720px;
+  }
+  @media screen and (min-width: 992px) {
+    width: 960px;
+  }
+  @media screen and (min-width: 1200px) {
+    width: 1140px;
   }
 `;
 


### PR DESCRIPTION
This PR is to improve a few things I noticed with PR #422:

- Replaced these weird styles for the base `HorizontalContainer` so that our page content has more standard widths at different breakpoints (I used sizes from Bootstrap) and is always centered:
![image](https://user-images.githubusercontent.com/16946297/98993005-bacae500-24e2-11eb-926b-06b0b1de8ccc.png)


- Tweaked the breadcrumb and standalone links on the Resources page to fix these misalignment issues:
![image](https://user-images.githubusercontent.com/16946297/98992625-42642400-24e2-11eb-9275-faad64cbde94.png)
![Resources-page-alignment](https://user-images.githubusercontent.com/16946297/98992641-4728d800-24e2-11eb-8cf8-289ff8c59a2e.png)

- Fixed the height of the footer, it was like this:
![footer-height](https://user-images.githubusercontent.com/16946297/98992153-b0f4b200-24e1-11eb-9d85-18cd0c797c2a.png)

- Removed the spacing above the title on the Video Communication Platforms page:
![breadcrumb alignemnt](https://user-images.githubusercontent.com/16946297/98992544-2d879080-24e2-11eb-87a6-f358a49fde45.png)


