### PR TITLE
Add "Learn from Others" heading on homepage

### DIFF
--- a/react-frontend/src/components/Home/cardlist.js
+++ b/react-frontend/src/components/Home/cardlist.js
@@ -2,6 +2,7 @@ import React from 'react';
 import InfoCard from './infocard';
 import { Col, Row } from 'react-flexbox-grid';
 import { PageContainer } from '../StyleComponents/pageContent';
+import { Title2 } from '../StyleComponents/headings';
 
 const digitalFrameworkGrey = require('../../images/pngIllustrations/digitalFrameworkGrey.png');
 const digitalPrinciplesGrey = require('../../images/pngIllustrations/digitalPrinciplesGrey.png');
@@ -76,8 +77,11 @@ const CardList = () => {
             />
           </Col>
         </Row>
-      </PageContainer>
-      <PageContainer style={{ paddingTop: '90px' }}>
+        <Row style={{ paddingTop: '30px' }}>
+          <Col sm={12}>
+            <Title2>Learn from Others</Title2>
+          </Col>
+        </Row>
         <Row>
           <Col sm={12} md={6}>
             <InfoCard

--- a/react-frontend/src/components/StyleComponents/headings.js
+++ b/react-frontend/src/components/StyleComponents/headings.js
@@ -67,9 +67,9 @@ export const SimpleTextPageTitle = styled.h1`
   margin-top: 30px;
 `;
 export const Title2 = styled.h2`
-  font-size: 3rem;
-  font-weight: 700;
-  margin-top: 30px;
+  font-size: 31px;
+  font-weight: bold;
+  margin-bottom: 24px;
 `;
 export const Title3 = styled.h3`
   font-size: 2.5rem;


### PR DESCRIPTION
Fixes #421 

- Inserts "Learn from Others" `h2` above the Community and Case Studies cards at the bottom of the homepage

In the process I also:
- removed an unnecessary PageContainer
- updated the style for `Title2` to match the styles of other `h2`s used on other pages