### PR TITLE
This should allow all resource types from the dev namespace to be listed

### DIFF
--- a/openshift/templates/cicd.yaml
+++ b/openshift/templates/cicd.yaml
@@ -198,6 +198,13 @@ objects:
           - patch
           - delete
           - update
+      - apiGroups:
+          - ""
+        attributeRestrictions: null
+        resources:
+          - ResourceAll
+        verbs:
+          - list
   - apiVersion: authorization.openshift.io/v1
     kind: RoleBinding
     metadata:


### PR DESCRIPTION
This is an attempt to allow the tools namespace to list all resource types. This is to allow the deletion/clean up of closed PR's to run error free.
Since this is my first time modifying one of these yaml files, I'm hoping to get a codereview before merging it in @parulmishra