### PR TITLE
Fixed the BC Sans styling

### DIFF
--- a/react-frontend/src/components/Nav/footer.js
+++ b/react-frontend/src/components/Nav/footer.js
@@ -52,11 +52,7 @@ const Footer = () => {
             </FooterLink>
           </FooterListItem>
           <FooterListItem>
-            <FooterLink
-              href="https://www2.gov.bc.ca/gov/content/home/get-help-with-government-services"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <FooterLink href="mailto:digital.government@gov.bc.ca">
               Contact Us
             </FooterLink>
           </FooterListItem>

--- a/react-frontend/src/components/Nav/navbar.js
+++ b/react-frontend/src/components/Nav/navbar.js
@@ -84,15 +84,17 @@ function NavBar() {
             <Col xs={11}>
               <NavBanner>
                 <NavBarHeaderLink
-                  href="https://gov.bc.ca"
-                  alt="Go to the Government of British Columbia website"
+                  href="/"
+                  alt="Go to the Digital.gov.bc.ca home page."
                 >
-                  <NavImage
-                    src={logoPath}
-                    alt="Go to the Government of British Columbia website"
-                  />
+                  <NavTitle>
+                    <NavImage
+                      src={logoPath}
+                      alt="Go to the Digital.gov.bc.ca home page."
+                    />{' '}
+                    Digital Government
+                  </NavTitle>
                 </NavBarHeaderLink>
-                <NavTitle>Digital Government</NavTitle>
                 <SkipToMainContent>Skip to main content</SkipToMainContent>
               </NavBanner>
             </Col>

--- a/react-frontend/src/components/Nav/navbar.js
+++ b/react-frontend/src/components/Nav/navbar.js
@@ -111,19 +111,11 @@ function NavBar() {
           <NavBarUl>
             <NavBarLi>
               <NavBarLinkFirst
-                to="/"
-                className={activePage === '/' ? 'active' : 'notactive'}
-              >
-                Home
-              </NavBarLinkFirst>
-            </NavBarLi>
-            <NavBarLi>
-              <NavBarLink
                 to="/resources"
                 className={activePage === '/resources' ? 'active' : 'notactive'}
               >
                 Resources
-              </NavBarLink>
+              </NavBarLinkFirst>
             </NavBarLi>
             <NavBarLi>
               <NavBarLink

--- a/react-frontend/src/components/StyleComponents/badge.js
+++ b/react-frontend/src/components/StyleComponents/badge.js
@@ -8,7 +8,7 @@ export const Badge = styled.span.attrs({
   height: 25px;
   padding: 3px 8px 3px 8px;
   color: black;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 12px;
   font-weight: normal;
   line-height: 20px;

--- a/react-frontend/src/components/StyleComponents/bannerWithImage.js
+++ b/react-frontend/src/components/StyleComponents/bannerWithImage.js
@@ -84,7 +84,7 @@ export const BannerSideImgTitle = styled.h1.attrs({
   className: 'bannerTitle',
 })`
   color: #313132;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 37px;
   font-weight: bold;
   line-height: 1.2;
@@ -100,7 +100,7 @@ export const BannerSideImgSubTitle = styled.div.attrs({
   className: 'subTitle',
 })`
   color: #313132;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 19px;
   text-align: left;
   @media only screen and (max-width: 800px) {

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -64,7 +64,7 @@ export const CardHorizontalText = styled.div.attrs({
 export const CardHorizontalTitle = styled.h5.attrs({
   className: 'cardHorizontalTitle',
 })`
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 31px;
   font-weight: bold;
   line-height: 1.2;
@@ -110,7 +110,7 @@ export const CardLinkDiv = styled.div.attrs({
 export const CardTitle = styled.h5.attrs({
   className: 'cardTitle',
 })`
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 31px;
   font-weight: bold;
   line-height: 1.2;
@@ -130,6 +130,6 @@ export const Icon = styled.img.attrs({
 export const IconCol = styled(Col).attrs({
   className: 'iconCol',
 })`
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-weight: bold;
 `;

--- a/react-frontend/src/components/StyleComponents/htmlTags.js
+++ b/react-frontend/src/components/StyleComponents/htmlTags.js
@@ -28,7 +28,7 @@ export const BreadcrumbUL = styled.ul`
 
 export const CovidCol = styled(Col)`
   color: #fff;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 18px;
 `;
 
@@ -124,7 +124,7 @@ export const HrefLink = styled.a.attrs({
   className: 'productCardLink',
 })`
   color: #1a5a96;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   text-decoration: underline;
   :focus {
     outline: -webkit-focus-ring-color auto 5px;
@@ -139,7 +139,7 @@ export const HrefLinkStandalone = styled.a.attrs({
   className: 'externalLink',
 })`
   color: #1a5a96;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 16px;
   font-weight: bold;
   margin-bottom: 16px;
@@ -157,7 +157,7 @@ export const HrefLinkStandaloneInternal = styled(Link).attrs({
   className: 'internalLink',
 })`
   color: #1a5a96;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 16px;
   font-weight: bold;
   margin-bottom: 16px;
@@ -175,7 +175,7 @@ export const HrefLinkInternal = styled(Link).attrs({
   className: 'internalLink',
 })`
   color: #1a5a96;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-weight: bold;
   text-decoration: underline;
   :focus {
@@ -191,7 +191,7 @@ export const HrefLinkScrollTo = styled(ScrollTo).attrs({
   activeClass: 'active',
 })`
   color: #1a5a96;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   text-decoration: underline;
   :focus {
     outline: -webkit-focus-ring-color auto 5px;
@@ -230,7 +230,7 @@ export const NavBarLink = styled(Link).attrs({
 })`
   color: #fff;
   display: flex;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 16px;
   font-weight: normal; /* 400 */
   padding: 0 15px 0 15px;
@@ -253,7 +253,7 @@ export const NavBarLinkExternal = styled.a.attrs({
 })`
   color: #fff;
   display: flex;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 16px;
   font-weight: normal; /* 400 */
   padding: 0 15px 0 15px;
@@ -307,7 +307,7 @@ export const ResourceLinkRow = styled(Row)`
 export const StyledP = styled.p.attrs({
   className: 'digitalParagraph',
 })`
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 16px;
   position: relative;
 `;

--- a/react-frontend/src/components/StyleComponents/nav.js
+++ b/react-frontend/src/components/StyleComponents/nav.js
@@ -89,7 +89,7 @@ export const NavTitle = styled.p.attrs({
   className: 'navTitle',
 })`
   color: white;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-weight: normal;
   margin: 0px 5px 0px 25px;
 
@@ -114,7 +114,7 @@ export const SkipToMainContent = styled.a.attrs({
   'aria-label': 'Skip to main content',
 })`
   color: #fcba19;
-  font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 16px;
   line-height: 1.5;
   margin: 5px 0 0 -5000px;

--- a/react-frontend/src/components/StyleComponents/nav.js
+++ b/react-frontend/src/components/StyleComponents/nav.js
@@ -62,10 +62,6 @@ export const NavImage = styled.img.attrs({
     margin-right: 0px;
     margin-top: -5px;
   }
-
-  @media screen and (max-width: 400px) {
-    margin-right: 25px;
-  }
 `;
 
 export const NavMain = styled.nav.attrs({
@@ -91,10 +87,10 @@ export const NavTitle = styled.p.attrs({
   color: white;
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-weight: normal;
-  margin: 0px 5px 0px 25px;
+  margin: 0px 5px 0px 0px;
 
   @media screen and (min-width: 900px) {
-    font-size: 28px;
+    font-size: 20px;
     visibility: visible;
   }
   @media screen and (min-width: 400px) and (max-width: 899px) {

--- a/react-frontend/src/index.css
+++ b/react-frontend/src/index.css
@@ -9,7 +9,7 @@
 }
 
 p, h1, h2, h3, h4, li {
-    font-family: ‘BC Sans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
+    font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
     color: #313132;
     font-size: 16px;
 }


### PR DESCRIPTION
Since this pr is exclusively styling, I'm comfortable with having @mark-a-wilson or @singhinderdeep  doing the code review.
- This fixes the styling on the site so that the BC sans font actually gets used. #523
- Turns the contact us link in the footer into a 'mail to' link #526
- Turns the logo into a single link to digital.gov.bc.ca home page #412