### PR TITLE
Removed the covid banner and add youtube video

### DIFF
--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -6686,6 +6686,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -11272,6 +11277,11 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loader-fs-cache": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.3.tgz",
@@ -11634,6 +11644,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -15084,6 +15099,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
       "integrity": "sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw=="
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-flexbox-grid": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/react-flexbox-grid/-/react-flexbox-grid-2.1.2.tgz",
@@ -15111,6 +15131,18 @@
         "unified": "^6.1.5",
         "unist-util-visit": "^1.3.0",
         "xtend": "^4.0.1"
+      }
+    },
+    "react-player": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.8.2.tgz",
+      "integrity": "sha512-AiCvWJGpFxgxjwMxDMiaeTyL2IgDaKuPZfERzNULGPx7X67Mh9D0UqKZG6YHqJQ1KbpbCdE0VBtICrzRxr28pg==",
+      "requires": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
       }
     },
     "react-router": {

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^16.14.0",
     "react-flexbox-grid": "^2.1.2",
     "react-markdown": "^4.3.1",
+    "react-player": "^2.8.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.4",
     "react-scroll": "^1.8.0",

--- a/react-frontend/src/components/CaseStudies/caseStudy.js
+++ b/react-frontend/src/components/CaseStudies/caseStudy.js
@@ -73,7 +73,7 @@ const CaseStudy = () => {
             <CaseStudyHeading>
               Transforming the Medical Services Plan
             </CaseStudyHeading>
-            <ReactPlayer url={content.videoContent} width="auto" />
+            <ReactPlayer url={content.videoContent} width="auto" controls />
           </ContentBlockContainer>
         )}
         <ContentBlockContainer>

--- a/react-frontend/src/components/CaseStudies/caseStudy.js
+++ b/react-frontend/src/components/CaseStudies/caseStudy.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactPlayer from 'react-player';
 import { useParams } from 'react-router-dom';
 import DocumentTitle from 'react-document-title';
 import { MiningContent, FarmerContent, MedicalContent } from './content';
@@ -67,6 +68,14 @@ const CaseStudy = () => {
           <CaseStudyHeading>The Approach</CaseStudyHeading>
           {content.approach}
         </ContentBlockContainer>
+        {content.videoContent && (
+          <ContentBlockContainer>
+            <CaseStudyHeading>
+              Transforming the Medical Services Plan
+            </CaseStudyHeading>
+            <ReactPlayer url={content.videoContent} width="auto" />
+          </ContentBlockContainer>
+        )}
         <ContentBlockContainer>
           <CaseStudyHeading>Outcomes that Matter</CaseStudyHeading>
           {content.outcomes}

--- a/react-frontend/src/components/CaseStudies/content.js
+++ b/react-frontend/src/components/CaseStudies/content.js
@@ -398,6 +398,7 @@ const MedicalContent = {
       </ol>
     </div>
   ),
+  videoContent: 'https://youtu.be/U5SecUbCtyE',
   outcomes: (
     <div>
       <p>

--- a/react-frontend/src/components/Nav/navbar.js
+++ b/react-frontend/src/components/Nav/navbar.js
@@ -3,7 +3,6 @@ import { useLocation, useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
-import CovidBanner from '../../components/Nav/covidbanner';
 import { Row, Col } from 'react-flexbox-grid';
 
 import {
@@ -77,7 +76,7 @@ function NavBar() {
 
   return (
     <NavBarWrapper>
-      <CovidBanner />
+      {/* If a site banner is needed in the future, add the component here. (see CovidBanner code) */}
       <NavBarHeader>
         <NavBarContainer>
           <Row middle="xs">


### PR DESCRIPTION
This PR tackles 2 front end tickets:

- This removes the covid banner from the site. I decided to leave the code so that we can easily repurpose it if we need to add a banner at some point in the future. It's a good feature to keep handy. (#532)
- It adds the video to medical services case studies page (#237)

The pr is deployed [here](https://digital-gov-frontend-pr-543-c0cce6-dev.apps.silver.devops.gov.bc.ca/)