### PR TITLE
Removed remaining references to pathfinder namespace

### DIFF
--- a/.github/workflows/run-zap-scan.yaml
+++ b/.github/workflows/run-zap-scan.yaml
@@ -33,7 +33,7 @@ jobs:
               target = "https://digital-gov-frontend-test-c0cce6-test.apps.silver.devops.gov.bc.ca/";
             }
             else if('dev' == env) {
-              target = "https://digital-gov-frontend-pr-${{github.event.inputs.prnumber}}-c0cce6-dev.apps.silver.devops.gov.bc.ca"/;
+              target = "https://digital-gov-frontend-pr-${{github.event.inputs.prnumber}}-c0cce6-dev.apps.silver.devops.gov.bc.ca/";
             }
             core.exportVariable('TARGET', target);
       - name: Full ZAP Scan

--- a/.github/workflows/run-zap-scan.yaml
+++ b/.github/workflows/run-zap-scan.yaml
@@ -27,13 +27,13 @@ jobs:
             const env = "${{ github.event.inputs.environment }}";
             var target = '';
             if('prod' == env) { 
-              target = "https://digital-gov-frontend-prod-c0cce6-prod.pathfinder.gov.bc.ca/";
+              target = "https://digital-gov-frontend-prod-c0cce6-prod.apps.silver.devops.gov.bc.ca/";
             }
             else if('test' == env) {
-              target = "https://digital-gov-frontend-test-c0cce6-test.pathfinder.gov.bc.ca/";
+              target = "https://digital-gov-frontend-test-c0cce6-test.apps.silver.devops.gov.bc.ca/";
             }
             else if('dev' == env) {
-              target = "https://digital-gov-frontend-pr-${{github.event.inputs.prnumber}}-c0cce6-dev.pathfinder.gov.bc.ca/";
+              target = "https://digital-gov-frontend-pr-${{github.event.inputs.prnumber}}-c0cce6-dev.apps.silver.devops.gov.bc.ca"/;
             }
             core.exportVariable('TARGET', target);
       - name: Full ZAP Scan

--- a/ansible/create-gh-deployment.yaml
+++ b/ansible/create-gh-deployment.yaml
@@ -81,7 +81,7 @@
             description: "Deployment of {{ ref }} is now succeeded, you can view the logs in detail with oc logs dc/{{ react_infra_name }}-{{ suffix }}"
             state: success
             environment: "{{ gh_env }}"
-            environment_url: "https://{{ react_infra_name }}-{{ suffix }}-{{ namespace }}.pathfinder.gov.bc.ca"
+            environment_url: "https://{{ react_infra_name }}-{{ suffix }}-{{ namespace }}.apps.silver.devops.gov.bc.ca"
           status_code: 201
           body_format: json
           headers:


### PR DESCRIPTION
There are remaining references to the pathfinder project in our infracode.  This was causing the deployment link on pr's to send us to the wrong place.  I also found references in the zap scanner. I believe that they would have caused problems with zap scan.  The only other reference to pathfinder on develop branch is in the dc.yaml for react which has been corrected in a different PR.

I'm not certain if there's a way of testing this without merging the code into develop.