### PR TITLE
Coco home 528

### DIFF
--- a/react-frontend/src/components/CoCos/CoCoPageComponents/coCoBannerSideImage.js
+++ b/react-frontend/src/components/CoCos/CoCoPageComponents/coCoBannerSideImage.js
@@ -42,7 +42,7 @@ function CoCoBannerSideImage({
         </BannerSideImgText>
       </Col>
       <Col sm={12} md={6}>
-        <a href={coCoLink} target="_blank">
+        <a href={coCoLink} target="_blank" rel="noopener noreferrer">
           <BannerSideImageImg
             src={coCoImage}
             onError={onError}

--- a/react-frontend/src/components/CoCos/coCoCard.js
+++ b/react-frontend/src/components/CoCos/coCoCard.js
@@ -17,6 +17,18 @@ const peopleIcon = require('../../images/icons/conference-24.png');
 const priceIcon = require('../../images/icons/price-tag-24.png');
 const clockIcon = require('../../images/icons/stopWatch.png');
 
+const maintenanceStatusObj = {
+  ActiveDevelopment: 'Active Development',
+  Maintained: 'Maintained',
+  Abandoned: 'Abandoned',
+};
+
+const supportStructureObj = {
+  MonFriday: 'Mon-Fri',
+  TwentyfourSeven: '24/7',
+  None: 'None',
+};
+
 // This function will be used on coCoPage as well
 export const Badges = (status, maintenanceStatus, tags, colour) => {
   return (
@@ -33,7 +45,7 @@ export const Badges = (status, maintenanceStatus, tags, colour) => {
         background={colour}
         title="Maintenance Status"
       >
-        {maintenanceStatus}
+        {maintenanceStatusObj[maintenanceStatus]}
       </Badge>
       {/* Only display 3 tags */}
       {tags?.map((tag, i) => {
@@ -93,14 +105,7 @@ function CoCoCard({
             title="Number of Teams Using CoCo"
           >
             <Row center="xs" style={{ height: '18px' }}>
-              <Icon
-                src={peopleIcon}
-                style={{
-                  paddingRight: '2px',
-                  position: 'relative',
-                  top: '2px',
-                }}
-              />
+              <Icon src={peopleIcon} style={{ paddingRight: '2px' }} />
               {numberOfUsers}
             </Row>
             <Row center="xs">Teams</Row>
@@ -123,7 +128,7 @@ function CoCoCard({
             <Row center="xs" style={{ height: '18px' }}>
               <Icon src={assistantIcon} />
             </Row>
-            <Row center="xs">{supportSchedule}</Row>
+            <Row center="xs">{supportStructureObj[supportSchedule]}</Row>
           </IconCol>
         </Row>
       </CardStyled>

--- a/react-frontend/src/components/CoCos/coCoCard.js
+++ b/react-frontend/src/components/CoCos/coCoCard.js
@@ -21,10 +21,18 @@ const clockIcon = require('../../images/icons/stopWatch.png');
 export const Badges = (status, maintenanceStatus, tags, colour) => {
   return (
     <BadgeWrapper>
-      <Badge data-testid="status-badge" background={colour}>
+      <Badge
+        data-testid="status-badge"
+        background={colour}
+        title="Software Status"
+      >
         {status}
       </Badge>
-      <Badge data-testid="status-badge" background={colour}>
+      <Badge
+        data-testid="status-badge"
+        background={colour}
+        title="Maintenance Status"
+      >
         {maintenanceStatus}
       </Badge>
       {/* Only display 3 tags */}
@@ -58,22 +66,64 @@ function CoCoCard({
       <CardStyled>
         {Badges(status?.Status, status?.Maintenance, tags)}
         <CardTitle data-testid="title">{title}</CardTitle>
-        <CardDescription data-testid="description">
+        <CardDescription
+          data-testid="description"
+          style={{ marginBottom: '40px' }}
+        >
           {description}
         </CardDescription>
-        <Row center="xs">
-          <IconCol data-testid="cost" xs={6} sm={3}>
-            {' '}
-            <Icon src={priceIcon} /> {cost}
+        <Row
+          start="xs"
+          style={{ bottom: '20px', position: 'absolute', width: '90%' }}
+        >
+          <IconCol
+            data-testid="cost"
+            xs={3}
+            title="Cost Structure"
+            style={{ paddingLeft: '0' }}
+          >
+            <Row center="xs" style={{ height: '18px' }}>
+              <Icon src={priceIcon} />
+            </Row>
+            <Row center="xs">{cost}</Row>
           </IconCol>
-          <IconCol data-testid="user-count" xs={6} sm={3}>
-            <Icon src={peopleIcon} /> {numberOfUsers} Teams
+          <IconCol
+            data-testid="user-count"
+            xs={3}
+            title="Number of Teams Using CoCo"
+          >
+            <Row center="xs" style={{ height: '18px' }}>
+              <Icon
+                src={peopleIcon}
+                style={{
+                  paddingRight: '2px',
+                  position: 'relative',
+                  top: '2px',
+                }}
+              />
+              {numberOfUsers}
+            </Row>
+            <Row center="xs">Teams</Row>
           </IconCol>
-          <IconCol data-testid="onboarding-time" xs={6} sm={3}>
-            <Icon src={clockIcon} /> {onboardingTime}
+          <IconCol
+            data-testid="onboarding-time"
+            xs={3}
+            title="Estimate of Onboarding Time"
+          >
+            <Row center="xs" style={{ height: '18px' }}>
+              <Icon src={clockIcon} />
+            </Row>
+            <Row center="xs">{onboardingTime}</Row>
           </IconCol>
-          <IconCol data-testid="support-schedule" xs={6} sm={3}>
-            <Icon src={assistantIcon} /> {supportSchedule}
+          <IconCol
+            data-testid="support-schedule"
+            xs={3}
+            title="Support Availability"
+          >
+            <Row center="xs" style={{ height: '18px' }}>
+              <Icon src={assistantIcon} />
+            </Row>
+            <Row center="xs">{supportSchedule}</Row>
           </IconCol>
         </Row>
       </CardStyled>

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -125,6 +125,8 @@ export const Icon = styled.img.attrs({
   className: 'icon',
 })`
   height: 16px;
+  position: relative;
+  top: 2px;
 `;
 
 export const IconCol = styled(Col).attrs({

--- a/strapi-app/api/co-co/models/co-co.settings.json
+++ b/strapi-app/api/co-co/models/co-co.settings.json
@@ -51,9 +51,11 @@
     "SupportSchedule": {
       "type": "enumeration",
       "enum": [
-        "Anytime",
-        "MonFriday"
-      ]
+        "TwentyfourSeven",
+        "MonFriday",
+        "None"
+      ],
+      "required": true
     },
     "CoverImage": {
       "model": "file",

--- a/strapi-app/components/co-co/cost-details.json
+++ b/strapi-app/components/co-co/cost-details.json
@@ -2,7 +2,8 @@
   "collectionName": "components_co_co_cost_details",
   "info": {
     "name": "CostDetails",
-    "icon": "dollar-sign"
+    "icon": "dollar-sign",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -12,7 +13,7 @@
         "Free",
         "Freemium",
         "Paid",
-        "Subscription"
+        "SaaS"
       ],
       "required": true
     },


### PR DESCRIPTION
This PR implements styling feedback on the coco home page. #528 
It does 3 things
- makes the card more responsive
- formats some of the strapi data to have proper typesetting
- Modifies the existing coco content type to have better values for cost structure and support structure