### PR TITLE
Bugfix/deletedevdeployment

### DIFF
--- a/openshift/templates/cicdv2.yaml
+++ b/openshift/templates/cicdv2.yaml
@@ -55,6 +55,7 @@ objects:
           - get
           - list
           - update
+          - delete
       - apiGroups:
           - image.openshift.io
           - ""
@@ -65,6 +66,7 @@ objects:
           - create
           - get
           - list
+          - delete
       - apiGroups:
           - image.openshift.io
           - ""
@@ -75,6 +77,7 @@ objects:
           - list
           - patch
           - create
+          - delete
       - apiGroups:
           - build.openshift.io
           - ""


### PR DESCRIPTION
Fixing a bug in the role binding to enable deletion of buildconfig and build.