### PR TITLE
Add team name and ministry to coco card

### DIFF
--- a/react-frontend/src/components/CoCos/coCoCard.js
+++ b/react-frontend/src/components/CoCos/coCoCard.js
@@ -65,6 +65,7 @@ export const Badges = (status, maintenanceStatus, tags, colour) => {
 function CoCoCard({
   title,
   description,
+  nameAndMinistry,
   numberOfUsers,
   onboardingTime,
   supportSchedule,
@@ -77,7 +78,10 @@ function CoCoCard({
     <Link to={`/cocos/${uid}`}>
       <CardStyled>
         {Badges(status?.Status, status?.Maintenance, tags)}
-        <CardTitle data-testid="title">{title}</CardTitle>
+        <CardTitle data-testid="title" style={{ marginBottom: '0' }}>
+          {title}
+        </CardTitle>
+        <p>{nameAndMinistry}</p>
         <CardDescription
           data-testid="description"
           style={{ marginBottom: '40px' }}

--- a/react-frontend/src/components/CoCos/coCoCards.js
+++ b/react-frontend/src/components/CoCos/coCoCards.js
@@ -26,6 +26,7 @@ function CoCoCards() {
                     <CoCoCard
                       title={coCo.Name}
                       description={coCo.ShortDescription}
+                      nameAndMinistry={coCo.TeamNameAndMinistry}
                       numberOfUsers={coCo.NumberOfUsers}
                       onboardingTime={coCo.OnboardingTime}
                       supportSchedule={coCo.SupportSchedule}


### PR DESCRIPTION
This adds the team name and ministry component of the coco content model to the coco cards.