### PR TITLE
Style without directly using BC Sans Bold

### DIFF
--- a/react-frontend/public/index.html
+++ b/react-frontend/public/index.html
@@ -55,7 +55,7 @@
   </script>
 </head>
 
-<body>
+<body style="font-size: 16px;">
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <!--

--- a/react-frontend/src/components/StyleComponents/badge.js
+++ b/react-frontend/src/components/StyleComponents/badge.js
@@ -10,7 +10,6 @@ export const Badge = styled.span.attrs({
   color: black;
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 12px;
-  font-weight: normal;
   line-height: 20px;
   margin-right: 4px;
   margin-top: 6px;

--- a/react-frontend/src/components/StyleComponents/bannerWithImage.js
+++ b/react-frontend/src/components/StyleComponents/bannerWithImage.js
@@ -50,7 +50,7 @@ export const BannerTitle = styled.h1.attrs({
 })`
   color: white;
   font-size: 37px;
-  font-weight: bold;
+  font-weight: 700;
   line-height: 37px;
   margin-bottom: 10px;
   position: relative;
@@ -86,7 +86,7 @@ export const BannerSideImgTitle = styled.h1.attrs({
   color: #313132;
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 37px;
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1.2;
   margin-bottom: 10px;
   text-align: left;

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -66,7 +66,7 @@ export const CardHorizontalTitle = styled.h5.attrs({
 })`
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 31px;
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1.2;
   position: relative;
   @media only screen and (max-width: 800px) {
@@ -103,7 +103,7 @@ export const CardLinkDiv = styled.div.attrs({
 })`
   bottom: 25px;
   font-size: 16px;
-  font-weight: bold;
+  font-weight: 700;
   position: absolute;
 `;
 
@@ -112,7 +112,7 @@ export const CardTitle = styled.h5.attrs({
 })`
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 31px;
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1.2;
   position: relative;
   @media only screen and (max-width: 800px) {
@@ -133,5 +133,5 @@ export const IconCol = styled(Col).attrs({
   className: 'iconCol',
 })`
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
-  font-weight: bold;
+  font-weight: 700;
 `;

--- a/react-frontend/src/components/StyleComponents/headings.js
+++ b/react-frontend/src/components/StyleComponents/headings.js
@@ -4,7 +4,6 @@ export const Heading = styled.h2.attrs({
   className: 'heading',
 })`
   font-size: 22pt;
-  font-weight: bold;
   line-height: 24pt;
 `;
 
@@ -12,7 +11,6 @@ export const SubHeading = styled.h3.attrs({
   className: 'subHeading',
 })`
   font-size: 18pt;
-  font-weight: bold;
   line-height: 24pt;
 `;
 
@@ -49,7 +47,6 @@ export const ResourcePageHeading = styled.h2.attrs({
   className: 'resourceHeading',
 })`
   font-size: 31px;
-  font-weight: bold;
   margin-bottom: 24px;
 `;
 
@@ -57,28 +54,22 @@ export const ResourcePageSubHeading = styled.h3.attrs({
   className: 'resourceSubHeading',
 })`
   font-size: 16pt;
-  font-weight: bold;
   margin-bottom: 10px;
 `;
 
 export const SimpleTextPageTitle = styled.h1`
   font-size: 3rem;
-  font-weight: 700;
   margin-top: 30px;
 `;
 export const Title2 = styled.h2`
   font-size: 31px;
-  font-weight: bold;
   margin-bottom: 24px;
 `;
 export const Title3 = styled.h3`
   font-size: 2.5rem;
-  font-weight: 700;
-
   margin-top: 30px;
 `;
 export const Title4 = styled.h4`
   font-size: 2.25rem;
-  font-weight: 700;
   margin-top: 28px;
 `;

--- a/react-frontend/src/components/StyleComponents/htmlTags.js
+++ b/react-frontend/src/components/StyleComponents/htmlTags.js
@@ -74,13 +74,12 @@ export const CovidLinkStyle = styled.a.attrs({
 `;
 
 export const CovidLinkStyleButton = styled(CovidLinkStyle)`
-  font-weight: bold;
+  font-weight: 700;
   text-decoration: none;
 `;
 
 export const DigitalFrameworkHeading = styled.h4`
   font-size: 21.6px;
-  font-weight: bold;
   padding-top: 20px;
 `;
 
@@ -188,7 +187,7 @@ export const HrefLinkStandalone = styled.a.attrs({
   color: #1a5a96;
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 16px;
-  font-weight: bold;
+  font-weight: 700;
   margin-bottom: 16px;
   text-decoration: underline;
   :focus {
@@ -206,7 +205,7 @@ export const HrefLinkStandaloneInternal = styled(Link).attrs({
   color: #1a5a96;
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 16px;
-  font-weight: bold;
+  font-weight: 700;
   margin-bottom: 16px;
   text-decoration: underline;
   :focus {
@@ -223,7 +222,7 @@ export const HrefLinkInternal = styled(Link).attrs({
 })`
   color: #1a5a96;
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
-  font-weight: bold;
+  font-weight: 700;
   text-decoration: underline;
   :focus {
     outline: -webkit-focus-ring-color auto 5px;
@@ -337,7 +336,7 @@ export const NavBarUl = styled.ul.attrs({
   padding-left: 0;
   padding-top: 8px;
   .active {
-    font-weight: bold;
+    font-weight: 700;
     text-decoration: underline;
     text-decoration-color: #fff;
   }

--- a/react-frontend/src/components/StyleComponents/htmlTags.js
+++ b/react-frontend/src/components/StyleComponents/htmlTags.js
@@ -6,6 +6,7 @@ import { Row, Col } from 'react-flexbox-grid';
 // This file contains styling for Link, a, ul, li, col, row, p html tags
 
 export const BreadcrumbLI = styled.li`
+  color: black;
   display: flex;
   font-size: 16px;
   font-weight: normal;

--- a/react-frontend/src/components/StyleComponents/styledMarkdown.js
+++ b/react-frontend/src/components/StyleComponents/styledMarkdown.js
@@ -15,29 +15,3 @@ export const ReactMarkdownStyled = styled(ReactMarkdown)`
     }
   }
 `;
-
-export const MarkdownStyles = styled.div`
-  & > h1 {
-    font-size: 3rem;
-    font-weight: 700;
-    margin-top: 30px;
-  }
-
-  & > h2 {
-    font-size: 3rem;
-    font-weight: 700;
-    margin-top: 30px;
-  }
-
-  & > h3 {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-top: 30px;
-  }
-
-  & > h4 {
-    font-size: 2.25rem;
-    font-weight: 700;
-    margin-top: 28px;
-  }
-`;

--- a/react-frontend/src/index.css
+++ b/react-frontend/src/index.css
@@ -1,4 +1,4 @@
-@font-face {
+/* @font-face {
     font-family: 'BC Sans';
     font-style: normal;
     src: local('BC Sans'), local('BCSans'),
@@ -6,6 +6,27 @@
         url(./fonts/BCSans-BoldItalic.woff)format('woff'),
         url(./fonts/BCSans-Bold.woff)format('woff'),
         url(./fonts/BCSans-Italic.woff)format('woff');
+} */
+@font-face {
+    font-family: 'BC Sans';
+    font-style: normal;
+    src: url('./fonts/BCSans-Regular.woff') format('woff'); /* Modern Browsers */
+}
+@font-face {
+    font-family: 'BC Sans';
+    font-style: italic;
+    src: url('./fonts/BCSans-Italic.woff') format('woff'); /* Modern Browsers */
+}
+@font-face {
+    font-family: 'BC Sans';
+    font-weight: 700;
+    src: url('./fonts/BCSans-Bold.woff') format('woff'); /* Modern Browsers */
+}
+@font-face {
+    font-family: 'BC Sans';
+    font-style: italic;
+    font-weight: 700;
+    src: url('./fonts/BCSans-BoldItalic.woff') format('woff'); /* Modern Browsers */
 }
 
 p, h1, h2, h3, h4, li {
@@ -15,5 +36,5 @@ p, h1, h2, h3, h4, li {
 }
 
 h1, h2, h3, h4 {
-    font-weight: bold;
+    font-weight: 700;
 }

--- a/react-frontend/src/index.css
+++ b/react-frontend/src/index.css
@@ -1,12 +1,3 @@
-/* @font-face {
-    font-family: 'BC Sans';
-    font-style: normal;
-    src: local('BC Sans'), local('BCSans'),
-        url(./fonts/BCSans-Regular.woff)format('woff'),
-        url(./fonts/BCSans-BoldItalic.woff)format('woff'),
-        url(./fonts/BCSans-Bold.woff)format('woff'),
-        url(./fonts/BCSans-Italic.woff)format('woff');
-} */
 @font-face {
     font-family: 'BC Sans';
     font-style: normal;

--- a/react-frontend/src/index.css
+++ b/react-frontend/src/index.css
@@ -38,3 +38,8 @@ p, h1, h2, h3, h4, li {
 h1, h2, h3, h4 {
     font-weight: 700;
 }
+
+strong, b {
+    font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
+    font-weight: 700 !important;
+}


### PR DESCRIPTION
This is a styling experiment, a much better way of using BC Sans Bold in the css
I believe this is the correct way of implementing the BC Sans Bold (it is now inline with the markdown page)