### PR TITLE
Removing the install oc step

### DIFF
--- a/.github/workflows/deploy-react-to-dev.yaml
+++ b/.github/workflows/deploy-react-to-dev.yaml
@@ -32,8 +32,7 @@ jobs:
         rm oc.tar.gz
         oc version
         python --version
-        python -m pip install -U pip setuptools
-        pip install openshift
+        pip3 install ansible openshift
     - name: login to oc client
       run: ansible-playbook ansible/oc-login.yaml -e OPENSHIFT_SERVER_URL=${{ secrets.OPENSHIFT_SERVER_URL_OC4 }} -e CICD_SA_ACCOUNT_TOKEN=${{ secrets.CICD_SA_ACCOUNT_TOKEN_OC4 }}
     - name: build react app

--- a/.github/workflows/deploy-react-to-dev.yaml
+++ b/.github/workflows/deploy-react-to-dev.yaml
@@ -18,18 +18,19 @@ jobs:
         script: |
           const prNumber = context.payload.number;
           core.exportVariable('PULL_NUMBER', prNumber);
-    # - name: install oc
-    #   # manually installing oc, i've opened up an issue with  github actions to include this since they
-    #   # already have kubectl https://github.com/actions/virtual-environments/issues/1083
-    #   run: |
+    - name: install oc
+      # manually installing oc, i've opened up an issue with  github actions to include this since they
+      # already have kubectl https://github.com/actions/virtual-environments/issues/1083
+      run: |
         
-    #     curl -O https://mirror.openshift.com/pub/openshift-v3/clients/3.11.232/linux/oc.tar.gz > oc.tar.gz
-    #     tar xvzf oc.tar.gz 
-    #     ls -l
-    #     sudo mv oc /usr/local/bin
-    #     rm oc.tar.gz
-    #     oc version
-    #     pip install openshift
+        curl -O https://mirror.openshift.com/pub/openshift-v3/clients/3.11.232/linux/oc.tar.gz > oc.tar.gz
+        tar xvzf oc.tar.gz 
+        ls -l
+        sudo mv oc /usr/local/bin
+        rm oc.tar.gz
+        oc version
+        pip install --upgrade setuptools
+        pip install openshift
     - name: login to oc client
       run: ansible-playbook ansible/oc-login.yaml -e OPENSHIFT_SERVER_URL=${{ secrets.OPENSHIFT_SERVER_URL_OC4 }} -e CICD_SA_ACCOUNT_TOKEN=${{ secrets.CICD_SA_ACCOUNT_TOKEN_OC4 }}
     - name: build react app

--- a/.github/workflows/deploy-react-to-dev.yaml
+++ b/.github/workflows/deploy-react-to-dev.yaml
@@ -18,18 +18,18 @@ jobs:
         script: |
           const prNumber = context.payload.number;
           core.exportVariable('PULL_NUMBER', prNumber);
-    - name: install oc
-      # manually installing oc, i've opened up an issue with  github actions to include this since they
-      # already have kubectl https://github.com/actions/virtual-environments/issues/1083
-      run: |
+    # - name: install oc
+    #   # manually installing oc, i've opened up an issue with  github actions to include this since they
+    #   # already have kubectl https://github.com/actions/virtual-environments/issues/1083
+    #   run: |
         
-        curl -O https://mirror.openshift.com/pub/openshift-v3/clients/3.11.232/linux/oc.tar.gz > oc.tar.gz
-        tar xvzf oc.tar.gz 
-        ls -l
-        sudo mv oc /usr/local/bin
-        rm oc.tar.gz
-        oc version
-        pip install openshift
+    #     curl -O https://mirror.openshift.com/pub/openshift-v3/clients/3.11.232/linux/oc.tar.gz > oc.tar.gz
+    #     tar xvzf oc.tar.gz 
+    #     ls -l
+    #     sudo mv oc /usr/local/bin
+    #     rm oc.tar.gz
+    #     oc version
+    #     pip install openshift
     - name: login to oc client
       run: ansible-playbook ansible/oc-login.yaml -e OPENSHIFT_SERVER_URL=${{ secrets.OPENSHIFT_SERVER_URL_OC4 }} -e CICD_SA_ACCOUNT_TOKEN=${{ secrets.CICD_SA_ACCOUNT_TOKEN_OC4 }}
     - name: build react app

--- a/.github/workflows/deploy-react-to-dev.yaml
+++ b/.github/workflows/deploy-react-to-dev.yaml
@@ -8,7 +8,7 @@ on: [pull_request]
 #       - 'ansible/deploy-react.yaml'
 jobs:
   run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2

--- a/.github/workflows/deploy-react-to-dev.yaml
+++ b/.github/workflows/deploy-react-to-dev.yaml
@@ -22,14 +22,13 @@ jobs:
       # manually installing oc, i've opened up an issue with  github actions to include this since they
       # already have kubectl https://github.com/actions/virtual-environments/issues/1083
       run: |
-        
         curl -O https://mirror.openshift.com/pub/openshift-v3/clients/3.11.232/linux/oc.tar.gz > oc.tar.gz
         tar xvzf oc.tar.gz 
         ls -l
         sudo mv oc /usr/local/bin
         rm oc.tar.gz
         oc version
-        pip install --upgrade setuptools
+        python -m pip install -U pip setuptools
         pip install openshift
     - name: login to oc client
       run: ansible-playbook ansible/oc-login.yaml -e OPENSHIFT_SERVER_URL=${{ secrets.OPENSHIFT_SERVER_URL_OC4 }} -e CICD_SA_ACCOUNT_TOKEN=${{ secrets.CICD_SA_ACCOUNT_TOKEN_OC4 }}

--- a/.github/workflows/deploy-react-to-dev.yaml
+++ b/.github/workflows/deploy-react-to-dev.yaml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8.1'
     - name: Store PR Num in env
       uses: actions/github-script@v3
       with:
@@ -28,6 +31,7 @@ jobs:
         sudo mv oc /usr/local/bin
         rm oc.tar.gz
         oc version
+        python --version
         python -m pip install -U pip setuptools
         pip install openshift
     - name: login to oc client

--- a/ansible/build-react.yaml
+++ b/ansible/build-react.yaml
@@ -7,6 +7,7 @@
       image_namespace: "{{ tools_namespace }}"
       suffix: "{{ version }}"
       infra_name: "{{ react_infra_name }}"
+      ansible_python_interpreter: '{{ ansible_playbook_python }}'
     tasks:
       - name: Pre checks
         include: ./tasks/check_pr_exists.yaml

--- a/ansible/build-react.yaml
+++ b/ansible/build-react.yaml
@@ -7,7 +7,6 @@
       image_namespace: "{{ tools_namespace }}"
       suffix: "{{ version }}"
       infra_name: "{{ react_infra_name }}"
-      ansible_python_interpreter: '{{ ansible_playbook_python }}'
     tasks:
       - name: Pre checks
         include: ./tasks/check_pr_exists.yaml


### PR DESCRIPTION
Looks like Ubuntu images come with OC already installed. Trying out a run by commenting out the install oc step. Refer: https://github.com/redhat-actions/oc-login