### PR TITLE
Reverse Proxy Configuration

### DIFF
--- a/openshift/templates/react-frontend/README.md
+++ b/openshift/templates/react-frontend/README.md
@@ -8,6 +8,24 @@ In other words
 
 The deployment is fairly simple, caddy2 will recieve a __Caddyfile__ configmap and a deployment config manages its lifecycle. 
 
+## Reverse Proxy
+
+Reverse proxy's are configured in the `./dc.yaml` file.
+
+### Digital Marketplace
+
+The route `/marketplace` redirects to the digital marketplace app.  This behaves defferently in the 3 nampaces.
+- dev: Current Digintal.gov dev deployements proxy to the Marketplace dev deployment. Marketplace's dev deployment is currently configured in a way that does not render the site from this url. Though the user will be prompted to login.
+- test: The Digintal.gov test deployement is proxied to the Marketplace test deployment.
+The current configuration of the marketplace app will work properly when accessed from `https://digital-gov-frontend-test-c0cce6-test.apps.silver.devops.gov.bc.ca/marketplace` (once they log in, contact Digital Marketplace admins for credentials).
+- prod: Only users from digital.gov.bc.ca/marketplace will be able to access the marketplace app.
+
+#### Configuring Marketplace App 
+
+To allow the marketplace app proxy to function the marketplace app must have environment variables set in three places.
+1) The env variable `PATH_PREFIX='marketplace'` must be added to relevant build in the marketplace tools namspace. Then the project needs to be re-built.
+2) In the relevant namespace the Config Map  `app-digmkt-${NAMESPACE}-config` must have the variables `ORIGIN` and `PATH_PREFIX='marketplace'` set.  `ORIGIN=https://digital-gov-frontend-test-c0cce6-test.apps.silver.devops.gov.bc.ca/marketplace` for test.
+3) In order for Keycloak autentication to work, the digital gov url has to be whitelisted in the Marketplace keycloak test realm.  
 
 ## Labels
 

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -100,7 +100,7 @@ objects:
       handle /marketplace* {
         # handle path not working
         uri strip_prefix /marketplace
-        reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca {
+        reverse_proxy https://app-digmkt-${NAMESPACE}.apps.silver.devops.gov.bc.ca {
           header_up Host {http.reverse_proxy.upstream.host}
           flush_interval -1
         }

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -97,14 +97,9 @@ objects:
       Caddyfile: |
         :4000
 
-        handle_path /marketplace/* {
-          reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca {
-            header_up Host {http.reverse_proxy.upstream.host}
-            flush_interval -1
-          }
-        }
-
         handle {
+          reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca 
+
           # for app
           root * /opt/app-root/src
 

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -98,8 +98,12 @@ objects:
       :4000
  
       handle /marketplace* {
-        reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca
-        # respond "Hello Jonathan"
+        # handle path not working
+        uri strip_prefix /marketplace
+        reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca {
+          header_up Host {http.reverse_proxy.upstream.host}
+          flush_interval -1
+        }
       }
    
       handle /* {
@@ -115,7 +119,8 @@ objects:
           Cache-Control "public, max-age=0, must-revalidate"
         }
       }
-
+   
+   
       log {
         output stderr
         output stdout 

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -98,7 +98,7 @@ objects:
         :4000
 
         handle_path /marketplace/* {
-          reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca/ {
+          reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca {
             header_up Host {http.reverse_proxy.upstream.host}
             flush_interval -1
           }

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -95,38 +95,38 @@ objects:
   - apiVersion: v1
     data:
       Caddyfile: |
-      :4000
- 
-      handle /marketplace* {
-        # handle path not working
-        uri strip_prefix /marketplace
-        reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca {
-          header_up Host {http.reverse_proxy.upstream.host}
-          flush_interval -1
+        :4000
+  
+        handle /marketplace* {
+          # handle path not working
+          uri strip_prefix /marketplace
+          reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca {
+            header_up Host {http.reverse_proxy.upstream.host}
+            flush_interval -1
+          }
         }
-      }
-   
-      handle /* {
-        # for app
-        root * /opt/app-root/src
-        file_server 
-        encode gzip
-   
-        try_files {path} {path}/ /index.html
-   
-        header / {
-          # prevent any static html from being cached
-          Cache-Control "public, max-age=0, must-revalidate"
+    
+        handle /* {
+          # for app
+          root * /opt/app-root/src
+          file_server 
+          encode gzip
+    
+          try_files {path} {path}/ /index.html
+    
+          header / {
+            # prevent any static html from being cached
+            Cache-Control "public, max-age=0, must-revalidate"
+          }
         }
-      }
-   
-   
-      log {
-        output stderr
-        output stdout 
-        format single_field common_log
-        level info
-      }  
+    
+    
+        log {
+          output stderr
+          output stdout 
+          format single_field common_log
+          level info
+        }  
     kind: ConfigMap
     metadata:
       labels:

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -104,24 +104,26 @@ objects:
           }
         }
 
-        # for app
-        root * /opt/app-root/src
+        handle {
+          # for app
+          root * /opt/app-root/src
 
-        file_server 
-        encode gzip
+          file_server 
+          encode gzip
 
-        try_files {path} {path}/ /index.html
+          try_files {path} {path}/ /index.html
+
+          header / {
+            # prevent any static html from being cached
+            Cache-Control "public, max-age=0, must-revalidate"
+          }
+        }
 
         log {
           output stderr
           output stdout 
           format single_field common_log
           level info
-        }
-
-        header / {
-          # prevent any static html from being cached
-          Cache-Control "public, max-age=0, must-revalidate"
         }
     kind: ConfigMap
     metadata:

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -100,7 +100,7 @@ objects:
       handle /marketplace* {
         # handle path not working
         uri strip_prefix /marketplace
-        reverse_proxy https://app-digmkt-${NAMESPACE}.apps.silver.devops.gov.bc.ca {
+        reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca {
           header_up Host {http.reverse_proxy.upstream.host}
           flush_interval -1
         }

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -95,31 +95,33 @@ objects:
   - apiVersion: v1
     data:
       Caddyfile: |
-        :4000
-
-        handle {
-          reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca 
-
-          # for app
-          root * /opt/app-root/src
-
-          file_server 
-          encode gzip
-
-          try_files {path} {path}/ /index.html
-
-          header / {
-            # prevent any static html from being cached
-            Cache-Control "public, max-age=0, must-revalidate"
-          }
+      :4000
+ 
+      handle /marketplace* {
+        reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca
+        # respond "Hello Jonathan"
+      }
+   
+      handle /* {
+        # for app
+        root * /opt/app-root/src
+        file_server 
+        encode gzip
+   
+        try_files {path} {path}/ /index.html
+   
+        header / {
+          # prevent any static html from being cached
+          Cache-Control "public, max-age=0, must-revalidate"
         }
+      }
 
-        log {
-          output stderr
-          output stdout 
-          format single_field common_log
-          level info
-        }
+      log {
+        output stderr
+        output stdout 
+        format single_field common_log
+        level info
+      }  
     kind: ConfigMap
     metadata:
       labels:

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -97,8 +97,8 @@ objects:
       Caddyfile: |
         :4000
 
-        handle_path /marketplace* {
-          reverse_proxy https://app-digmkt-prod.apps.silver.devops.gov.bc.ca {
+        handle_path /marketplace/* {
+          reverse_proxy https://app-digmkt-test.apps.silver.devops.gov.bc.ca/ {
             header_up Host {http.reverse_proxy.upstream.host}
             flush_interval -1
           }

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -97,6 +97,13 @@ objects:
       Caddyfile: |
         :4000
 
+        handle_path /marketplace* {
+          reverse_proxy https://app-digmkt-prod.apps.silver.devops.gov.bc.ca {
+            header_up Host {http.reverse_proxy.upstream.host}
+            flush_interval -1
+          }
+        }
+
         # for app
         root * /opt/app-root/src
 

--- a/react-frontend/src/components/Nav/navbar.js
+++ b/react-frontend/src/components/Nav/navbar.js
@@ -152,7 +152,7 @@ function NavBar() {
             </NavBarLi>
             <NavBarLi>
               <NavBarLinkExternal
-                href="https://digital.gov.bc.ca/marketplace"
+                href="/marketplace"
                 target="_blank"
               >
                 Marketplace


### PR DESCRIPTION
This reverse proxy's the Digital Marketplace test namespace instance to this PR's Digital Gov instance.

Todo:
- Add and env variable that can be configured in dev, test, and prod for whichever DigMarketplace instance DigGov should point to.