### PR TITLE
Add an error check

### DIFF
--- a/strapi-app/config/functions/cron.js
+++ b/strapi-app/config/functions/cron.js
@@ -19,7 +19,8 @@ module.exports = {
   //
   // }
   // Run once a day at 7:27AM  UTC (Midle of night BC)
-  '27 7 * * *': function () {
+  // '27 7 * * *': function () {
+  '0 * * * *': function () {
     strapi.config.functions.eventbrite()
   }
 };

--- a/strapi-app/config/functions/cron.js
+++ b/strapi-app/config/functions/cron.js
@@ -19,8 +19,7 @@ module.exports = {
   //
   // }
   // Run once a day at 7:27AM  UTC (Midle of night BC)
-  // '27 7 * * *': function () {
-  '0 * * * *': function () {
+  '27 7 * * *': function () {
     strapi.config.functions.eventbrite()
   }
 };

--- a/strapi-app/config/functions/eventbrite.js
+++ b/strapi-app/config/functions/eventbrite.js
@@ -93,6 +93,12 @@ module.exports = async () => {
             IsSeries: event.is_series,
             StartTime: event.start.utc,
             SeriesUID: event.series_id
+          }).catch(e => {
+            if (e.code == 11000) {
+              strapi.log.info("The event has already been uploaded.")
+            } else {
+              strapi.log.info(err)
+            }
           });
       }
 


### PR DESCRIPTION
This catches a non critical error
Error code 11000 is raised when strapi attempts to create an element that already exists.  It doesn't break anything and is expected when cron jobs are handled this way.