### PR TITLE
Set strapi default to dev

### DIFF
--- a/.github/workflows/deploy-strapi-to-dev-test-prod.yaml
+++ b/.github/workflows/deploy-strapi-to-dev-test-prod.yaml
@@ -7,7 +7,7 @@ on:
         required: true
       environment:
         required: true
-        default: 'test'
+        default: 'dev'
         description: 'Deploy environment'
 jobs:
   run:

--- a/openshift/templates/strapi/dc.yaml
+++ b/openshift/templates/strapi/dc.yaml
@@ -77,7 +77,13 @@ objects:
           memory:
             request: 150Mi
             limits: 250Mi
-        type: Recreate
+        rollingParams:
+          intervalSeconds: 1
+          maxSurge: 25%
+          maxUnavailable: 25%
+          timeoutSeconds: 1000
+          updatePeriodSeconds: 1
+        type: Rolling
       template:
         metadata:
           annotations:


### PR DESCRIPTION
Deployment is now 'rolling' instead of 'recreate'