### PR TITLE
Fix miscelanous bugs

### DIFF
--- a/react-frontend/src/components/Blog/blogNavigation.test.js
+++ b/react-frontend/src/components/Blog/blogNavigation.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { createMemoryHistory } from 'history';
-import { Router, Route, BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { render, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import BlogNavigation, { PrevNextButton } from './blogNavigation';
 import { AppConfig } from '../../providers/AppConfig';
 import { MockedProvider } from '@apollo/react-testing';
+import { renderWithRouterMatch } from '../../tests/helperFunctions/routerWrapper';
 
 const originalError = console.error;
 
@@ -24,31 +24,6 @@ beforeAll(() => {
 afterAll(() => {
   console.error = originalError;
 });
-
-// Using useParams makes testing difficult.  This fixes it.
-// https://medium.com/@aarling/mocking-a-react-router-match-object-in-your-component-tests-fa95904dcc55
-
-// // Helper function
-export function renderWithRouterMatch(
-  ui,
-  {
-    path = '/',
-    route = '/',
-    history = createMemoryHistory({ initialEntries: [route] }),
-  } = {}
-) {
-  return {
-    ...render(
-      <AppConfig>
-        <MockedProvider>
-          <Router history={history}>
-            <Route path={path} component={ui} />
-          </Router>
-        </MockedProvider>
-      </AppConfig>
-    ),
-  };
-}
 
 afterEach(cleanup);
 

--- a/react-frontend/src/components/CoCos/CoCoPageComponents/getStarted.js
+++ b/react-frontend/src/components/CoCos/CoCoPageComponents/getStarted.js
@@ -3,8 +3,9 @@ import React from 'react';
 import { Col, Row } from 'react-flexbox-grid';
 import { Heading } from '../../StyleComponents/headings';
 import { CoCoLinkExternal } from '../../StyleComponents/htmlTags';
+import { StyleRichText } from '../../StyleComponents/styledMarkdown';
 
-function GetStarted({ name, url }) {
+function GetStarted({ name, url, steps }) {
   return (
     <div style={{ marginTop: '60px' }}>
       <Row>
@@ -13,7 +14,10 @@ function GetStarted({ name, url }) {
         </Col>
       </Row>
       <Row>
-        <Col xs={12}>
+        <Col xs={12} data-testid="how-to-start">
+          {steps && (
+            <StyleRichText htmlOrMarkdown={steps} data-testid="how-to-start" />
+          )}
           <p>
             Select the "Start Using Now" button to visit the {name} Onboarding
             guide.

--- a/react-frontend/src/components/CoCos/coCoPage.js
+++ b/react-frontend/src/components/CoCos/coCoPage.js
@@ -19,7 +19,6 @@ import { PageContainer } from '../StyleComponents/pageContent';
 function CoCoPage() {
   const params = useParams();
   const ScrollElement = Scroll.Element;
-
   return (
     <DocumentTitle title="Common Components - Digital Government - Province of British Columbia">
       <PageContainer>
@@ -73,6 +72,7 @@ function CoCoPage() {
                 <GetStarted
                   name={coCos[0]?.Name}
                   url={coCos[0]?.GetStartedURL}
+                  steps={coCos[0]?.GetStartedSteps}
                 />
                 <ScrollElement name="support" className="element" />
                 <Support contact={coCos[0]?.Support} />

--- a/react-frontend/src/components/CoCos/coCoPage.test.js
+++ b/react-frontend/src/components/CoCos/coCoPage.test.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { MockedProvider } from '@apollo/react-testing';
+import '@testing-library/jest-dom/extend-expect';
+
+import CoCoPage from './coCoPage';
+import COCO_QUERY from '../../queries/coCos/coCo';
+
+import { AppConfig } from '../../providers/AppConfig';
+import { renderWithRouterMatch } from '../../tests/helperFunctions/routerWrapper';
+
+const originalError = console.error;
+
+beforeAll(() => {
+  console.error = (...args: any[]) => {
+    if (/Warning.*not wrapped in act/.test(args[0])) {
+      return;
+    }
+    if (/Error: connect ECONNREFUSED 127.0.0.1:80/.test(args[0])) {
+      return;
+    }
+    originalError.call(console, ...args);
+  };
+});
+
+afterAll(() => {
+  console.error = originalError;
+});
+
+afterEach(cleanup);
+
+it('renders the getstarted field correctly.', async () => {
+  const cocoPage = [
+    {
+      uid: 'keycloak',
+      Name: 'Keycloak 3',
+      Description: 'blfwfonreqgqer a shoferreq',
+      ProjectStatus: {
+        Maintenance: 'ActiveDevelopment',
+        Status: 'Mature',
+      },
+      TeamNameAndMinistry: 'KeyCloak Mistry of Magic',
+      Tags: [
+        {
+          name: 'API',
+        },
+        {
+          name: 'Bumble',
+        },
+      ],
+      CostStructure: {
+        Cost: 'Freemium',
+        PaymentStructure: 'regergergererfrf',
+      },
+      NumberOfUsers: 333,
+      OnboardingTime: 'Days',
+      SupportSchedule: 'MonFriday',
+      CoverImage: {
+        url: '/uploads/the_Gentleman_305308f135.png',
+      },
+      WhyShouldIUseThis: [
+        {
+          Heading: 'test 1',
+          Details: 'blha blah',
+        },
+        {
+          Heading: 'blah blah',
+          Details: 'blah blah blah ',
+        },
+        {
+          Heading: 'bublefa',
+          Details: 'nergeqrgeqr',
+        },
+      ],
+      WhoIsUsingThis: [
+        {
+          ministry: {
+            MinistryAcronym: 'EDUC',
+          },
+          Summary: 'jjj',
+        },
+        {
+          ministry: {
+            MinistryAcronym: 'FIN',
+          },
+          Summary: 'veavev',
+        },
+        {
+          ministry: {
+            MinistryAcronym: 'FIN',
+          },
+          Summary: 'bbhare',
+        },
+      ],
+      GetStartedURL: 'https://www.testgetstarted.com',
+      CoCoWebsite: 'https://www.CoCo.com',
+      GetStartedSteps: '<p>this is how you get started</p>',
+      ServiceLevelSupport:
+        '<h2>refeqrgeqrg</h2><p><strong>this is bold</strong></p><p><i><strong>this is bold italic</strong></i></p><p><a href="https://www.youtube.com">This<i><strong> </strong></i>Is a link</a></p><ul><li>bullet one</li><li>bullet two</li></ul><p>Numbering:</p><ol><li>number one</li><li>number two</li></ol>',
+      AdditionalTechnicalInformation: 'jbvafvfadv',
+      RequirementsAndRestrictions: 'rreracc',
+      Support: 'cdVVV',
+      MonthAndYearCreated: null,
+    },
+  ];
+
+  const mocks = [
+    {
+      request: {
+        query: COCO_QUERY,
+        variables: {
+          uid: 'keycloak',
+        },
+      },
+      result: {
+        data: {
+          coCos: cocoPage,
+        },
+      },
+    },
+  ];
+  const { getByText } = renderWithRouterMatch(
+    CoCoPage,
+    {
+      route: '/common-components/keycloak',
+      path: '/common-components/:uid',
+    },
+    mocks
+  );
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  expect(getByText('this is how you get started'));
+  // expect(getByTestId("how-to-start").getByText("this is how you get started"))//.toContain("this is how you get started");
+});

--- a/react-frontend/src/queries/coCos/coCos.js
+++ b/react-frontend/src/queries/coCos/coCos.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 const COCOS_QUERY = gql`
   query CoCos {
-    coCos {
+    coCos(sort: "Name:asc") {
       uid
       Name
       ShortDescription

--- a/react-frontend/src/tests/helperFunctions/routerWrapper.js
+++ b/react-frontend/src/tests/helperFunctions/routerWrapper.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { createMemoryHistory } from 'history';
+
+import { Router, Route } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import { AppConfig } from '../../providers/AppConfig';
+import { MockedProvider } from '@apollo/react-testing';
+
+// https://medium.com/@aarling/mocking-a-react-router-match-object-in-your-component-tests-fa95904dcc55
+
+//Whenever a page uses the useParams, the tested component needs to have them mocked
+// renderWithRouterMatch(BlogNavigation, {
+//   route: '/project/ABC123',
+//   path: '/project/:id',
+// });
+
+// renderWithRouterMatch(CoCoPage, {
+//   route: '/common-components/keycloak',
+//   path: '/common-components/:uid',
+// }, mocks);
+
+export function renderWithRouterMatch(
+  ui,
+  {
+    path = '/',
+    route = '/',
+    history = createMemoryHistory({ initialEntries: [route] }),
+  } = {},
+  mocks
+) {
+  return {
+    ...render(
+      <AppConfig>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Router history={history}>
+            <Route path={path} component={ui} />
+          </Router>
+        </MockedProvider>
+      </AppConfig>
+    ),
+  };
+}

--- a/strapi-app/api/blog-author/models/blog-author.settings.json
+++ b/strapi-app/api/blog-author/models/blog-author.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "blog_authors",
   "info": {
-    "name": "BlogAuthor",
+    "name": "Blog Author",
     "description": ""
   },
   "options": {

--- a/strapi-app/api/blog-post/models/blog-post.settings.json
+++ b/strapi-app/api/blog-post/models/blog-post.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "blog_posts",
   "info": {
-    "name": "Blog Post",
+    "name": "Blog Posts",
     "description": ""
   },
   "options": {

--- a/strapi-app/api/co-co/models/co-co.settings.json
+++ b/strapi-app/api/co-co/models/co-co.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "co_cos",
   "info": {
-    "name": "CommonComponent",
+    "name": "Common Components",
     "description": "This is the Common Component Collection Type."
   },
   "options": {
@@ -27,8 +27,8 @@
       "required": false
     },
     "Tags": {
-      "collection": "tag",
       "via": "co_cos",
+      "collection": "tag",
       "dominant": true
     },
     "TeamNameAndMinistry": {

--- a/strapi-app/api/community-page/models/community-page.settings.json
+++ b/strapi-app/api/community-page/models/community-page.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "community_pages",
   "info": {
-    "name": "CommunityPage",
+    "name": "Community Page",
     "description": ""
   },
   "options": {

--- a/strapi-app/api/digital-framework-progress/models/digital-framework-progress.settings.json
+++ b/strapi-app/api/digital-framework-progress/models/digital-framework-progress.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "digital_framework_progresses",
   "info": {
-    "name": "DigitalFrameworkProgress",
+    "name": "Digital Framework Progress",
     "description": ""
   },
   "options": {

--- a/strapi-app/api/learning-admin/models/learning-admin.settings.json
+++ b/strapi-app/api/learning-admin/models/learning-admin.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "learning_admins",
   "info": {
-    "name": "LearningAdmin",
+    "name": "Learning Admin",
     "description": ""
   },
   "options": {

--- a/strapi-app/api/tag/models/tag.settings.json
+++ b/strapi-app/api/tag/models/tag.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "tags",
   "info": {
-    "name": "CommonComponentTag",
+    "name": "Common Component Tags",
     "description": "This is a list tags that could describe any CoCo."
   },
   "options": {
@@ -17,8 +17,8 @@
       "unique": true
     },
     "co_cos": {
-      "via": "Tags",
-      "collection": "co-co"
+      "collection": "co-co",
+      "via": "Tags"
     }
   }
 }

--- a/strapi-app/api/user-feedback/models/user-feedback.settings.json
+++ b/strapi-app/api/user-feedback/models/user-feedback.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "user_feedbacks",
   "info": {
-    "name": "UserFeedback",
+    "name": "User Feedback",
     "description": ""
   },
   "options": {


### PR DESCRIPTION
This PR tackles the following
- adds common component get started steps #852 
- adds a test for the common component page
- Added spaces and pluralization to collection types #826
- Cocos are now displayed in alphabetical order by name.  (sorted by the COCOS_QUERY) #847 