### PR TITLE
implement consistent styling across clickable cards

### DIFF
--- a/react-frontend/src/components/Blog/blogCard.js
+++ b/react-frontend/src/components/Blog/blogCard.js
@@ -2,13 +2,13 @@ import React from 'react';
 import dateFormat from 'dateformat';
 import 'antd/dist/antd.css';
 import {
+  BlogCardAuthorLine,
+  BlogCardDescription,
+  BlogCardHeader,
+  BlogCardStyled,
   BlogCardThumnail,
   BlogCardThumnailNullImg,
-  BlogCardAuthorLine,
-  BlogCardStyled,
-  CardTitle,
-  CardDescription,
-  CommunityCardStyled,
+  BlogCardTitle,
 } from '../StyleComponents/card';
 
 function AuthorIcon({ url }) {
@@ -19,11 +19,9 @@ function AuthorIcon({ url }) {
         alt="avatar"
         style={{
           borderRadius: '50%',
-          display: 'inline-block',
           height: '24px',
-          verticalAlign: 'middle',
           width: '24px',
-          marginLeft: '4px',
+          marginRight: '6px',
         }}
         data-testid="authorImage"
       />
@@ -44,28 +42,31 @@ function BlogCard({
   return (
     <BlogCardStyled to={`/blog/${uid}`}>
       {coverImgSrc ? (
-        <BlogCardThumnail src={coverImgSrc} data-testid="thumbnail" />
+        <div>
+          <BlogCardThumnail src={coverImgSrc} data-testid="thumbnail" />
+        </div>
       ) : (
-        <BlogCardThumnailNullImg />
+        <div>
+          <BlogCardThumnailNullImg />
+        </div>
       )}
-      <div style={{ padding: '24px' }}>
+      <BlogCardHeader>
         <BlogCardAuthorLine>
-          <span>{author}</span>
-          <AuthorIcon url={authImg} />
-          <span style={{ float: 'right' }}>
-            {dateFormat(date, 'mmm d,yyyy')}
-          </span>
+          <div style={{ alignItems: 'center', display: 'flex' }}>
+            <AuthorIcon url={authImg} />
+            {author}
+          </div>
+          <div
+            style={{ alignItems: 'center', display: 'flex', height: '24px' }}
+          >
+            {dateFormat(date, 'mmm d, yyyy')}
+          </div>
         </BlogCardAuthorLine>
-        <CardTitle
-          style={{ fontSize: '25.92px', clear: 'both' }}
-          data-testid="title"
-        >
-          {title}
-        </CardTitle>
-        <CardDescription data-testid="description">
-          {description}
-        </CardDescription>
-      </div>
+        <BlogCardTitle data-testid="title">{title}</BlogCardTitle>
+      </BlogCardHeader>
+      <BlogCardDescription data-testid="description">
+        {description}
+      </BlogCardDescription>
     </BlogCardStyled>
   );
 }

--- a/react-frontend/src/components/CoCos/coCoCard.js
+++ b/react-frontend/src/components/CoCos/coCoCard.js
@@ -5,10 +5,10 @@ import { Link } from 'react-router-dom';
 
 import { Badge, BadgeWrapper } from '../StyleComponents/badge';
 import {
-  CommonComponentCardDescription,
-  CommonComponentCardHeader,
-  CommonComponentCardStyled,
-  CommonComponentCardTitle,
+  CoCoCardDescription,
+  CoCoCardHeader,
+  CoCoCardStyled,
+  CoCoCardTitle,
   Icon,
   IconCol,
 } from '../StyleComponents/card';
@@ -81,22 +81,20 @@ function CoCoCard({
 }) {
   return (
     <Link to={`/common-components/${uid}`}>
-      <CommonComponentCardStyled>
-        <CommonComponentCardHeader>
+      <CoCoCardStyled>
+        <CoCoCardHeader>
           {Badges(status?.Status, status?.Maintenance, tags)}
-          <CommonComponentCardTitle data-testid="title">
-            {title}
-          </CommonComponentCardTitle>
+          <CoCoCardTitle data-testid="title">{title}</CoCoCardTitle>
           <p style={{ marginBottom: '0' }}>{nameAndMinistry}</p>
           {/* This is commented out until a design desision is made */}
           {/* <CardDescription
             data-testid="description"
             style={{ marginBottom: '40px' }}
           > */}
-        </CommonComponentCardHeader>
-        <CommonComponentCardDescription data-testid="description">
+        </CoCoCardHeader>
+        <CoCoCardDescription data-testid="description">
           {description}
-        </CommonComponentCardDescription>
+        </CoCoCardDescription>
         {/* This is commented out until a design desision is made  */}
         {/* <Row
           start="xs"
@@ -147,7 +145,7 @@ function CoCoCard({
             <Row center="xs">{supportStructureObj[supportSchedule]}</Row>
           </IconCol>
         </Row> */}
-      </CommonComponentCardStyled>
+      </CoCoCardStyled>
     </Link>
   );
 }

--- a/react-frontend/src/components/CoCos/coCoCard.js
+++ b/react-frontend/src/components/CoCos/coCoCard.js
@@ -5,9 +5,10 @@ import { Link } from 'react-router-dom';
 
 import { Badge, BadgeWrapper } from '../StyleComponents/badge';
 import {
-  CardTitle,
-  CardDescription,
-  CardStyled,
+  CommonComponentCardDescription,
+  CommonComponentCardHeader,
+  CommonComponentCardStyled,
+  CommonComponentCardTitle,
   Icon,
   IconCol,
 } from '../StyleComponents/card';
@@ -80,20 +81,22 @@ function CoCoCard({
 }) {
   return (
     <Link to={`/common-components/${uid}`}>
-      <CardStyled>
-        {Badges(status?.Status, status?.Maintenance, tags)}
-        <CardTitle data-testid="title" style={{ marginBottom: '0' }}>
-          {title}
-        </CardTitle>
-        <p>{nameAndMinistry}</p>
-        {/* This is commented out until a design desision is made */}
-        {/* <CardDescription
-          data-testid="description"
-          style={{ marginBottom: '40px' }}
-        > */}
-        <CardDescription data-testid="description">
+      <CommonComponentCardStyled>
+        <CommonComponentCardHeader>
+          {Badges(status?.Status, status?.Maintenance, tags)}
+          <CommonComponentCardTitle data-testid="title">
+            {title}
+          </CommonComponentCardTitle>
+          <p style={{ marginBottom: '0' }}>{nameAndMinistry}</p>
+          {/* This is commented out until a design desision is made */}
+          {/* <CardDescription
+            data-testid="description"
+            style={{ marginBottom: '40px' }}
+          > */}
+        </CommonComponentCardHeader>
+        <CommonComponentCardDescription data-testid="description">
           {description}
-        </CardDescription>
+        </CommonComponentCardDescription>
         {/* This is commented out until a design desision is made  */}
         {/* <Row
           start="xs"
@@ -144,7 +147,7 @@ function CoCoCard({
             <Row center="xs">{supportStructureObj[supportSchedule]}</Row>
           </IconCol>
         </Row> */}
-      </CardStyled>
+      </CommonComponentCardStyled>
     </Link>
   );
 }

--- a/react-frontend/src/components/Learning/__snapshots__/eventCard.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/eventCard.test.js.snap
@@ -2,18 +2,18 @@
 
 exports[`renders correctly 1`] = `
 <div
-  className="sc-ieebsP bIJOHE cardRound"
+  className="sc-iJKOzS fyemee cardRound"
 >
   <img
-    className="sc-dJjZJu cpOIo"
+    className="sc-giYgFv bQjWCh"
     data-testid="thumbnail"
     src="https://testIMG.com"
   />
   <div
-    className="sc-dlVyqM dDrPTL"
+    className="sc-bYoCmx blBbma"
   >
     <h5
-      className="sc-egiSv kfuvTV cardTitle"
+      className="sc-hBURRC hepvD cardTitle"
       data-testid="title"
       style={
         Object {
@@ -30,7 +30,7 @@ exports[`renders correctly 1`] = `
       A great description
     </p>
     <a
-      className="sc-cTApHj kWJsjc externalLink"
+      className="sc-lbhJmS iDDnCG externalLink"
       href="https://test.com"
       rel="noopener noreferrer"
       style={

--- a/react-frontend/src/components/Learning/__snapshots__/events.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/events.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <div
-  className="sc-hiwReK sc-gGCCur hNuTMR fajAsF horizontalAlignment contentBlockContainer container"
+  className="sc-jIkYaL sc-hmjpBu bCTMzr irYcfK horizontalAlignment contentBlockContainer container"
   id="standards"
 >
   <div
@@ -12,7 +12,7 @@ exports[`renders correctly 1`] = `
       className="col-sm-12"
     >
       <h2
-        className="sc-jOxuqd icyiaT heading"
+        className="sc-fvxABq gKROXw heading"
       >
         Events
       </h2>

--- a/react-frontend/src/components/Learning/__snapshots__/learning.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/learning.test.js.snap
@@ -13,15 +13,15 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-md-6"
       >
         <div
-          className="sc-XxOsz eKCKYK sideImageText"
+          className="sc-bQtJOP imYTai sideImageText"
         >
           <h1
-            className="sc-ilftOa NbpEB bannerTitle"
+            className="sc-fXEqXD hGzgRq bannerTitle"
           >
             Learning
           </h1>
           <div
-            className="sc-uoixf dtjkkF subTitle"
+            className="sc-FNZbm cgblXZ subTitle"
           >
              
             Understand and adopt new approaches to teamwork and technology.
@@ -34,7 +34,7 @@ exports[`renders correctly 1`] = `
       >
         <img
           alt=""
-          className="sc-dkYRiW gAPpMG sideImage"
+          className="sc-jHkVfK gUVwSq sideImage"
         />
       </div>
     </div>
@@ -135,7 +135,7 @@ exports[`renders correctly 1`] = `
         >
           <img
             alt=""
-            className="sc-eGRTUG hGDprG sideImage"
+            className="sc-ilftOa jUqlCR sideImage"
           />
         </div>
       </div>
@@ -169,7 +169,7 @@ exports[`renders correctly 1`] = `
             Recent Episodes
           </h3>
           <a
-            className="sc-bTfYlY gaKhxs externalLink"
+            className="sc-gsNhcj bUDqQb externalLink"
             href="https://bcdevexchange.libsyn.com/"
             rel="noopener noreferrer"
             style={
@@ -218,7 +218,7 @@ exports[`renders correctly 1`] = `
         }
       >
         <div
-          className="ant-collapse-item sc-brSwnh lfLjfk PanelStyled"
+          className="ant-collapse-item sc-eGPWxh dqvFQb PanelStyled"
         >
           <div
             aria-expanded={false}

--- a/react-frontend/src/components/StyleComponents/badge.js
+++ b/react-frontend/src/components/StyleComponents/badge.js
@@ -37,5 +37,5 @@ export const BadgeWrapper = styled.div.attrs({
 })`
   display: flex;
   flex-wrap: wrap;
-  padding-bottom: 18px;
+  padding-bottom: 40px;
 `;

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -4,27 +4,71 @@ import { Col } from 'react-flexbox-grid';
 import { Link } from 'react-router-dom';
 
 const cardBorderRadius = '25px';
-const cardBorderInsetRadius = '21px';
+const cardBorderInsetRadius = '18px';
 
 export const BlogCardThumnail = styled.img`
   background: #003366;
-  border-radius: ${cardBorderRadius} ${cardBorderRadius} 0 0;
+  border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
   height: 200px;
   object-fit: cover;
   width: 100%;
 `;
 
 export const BlogCardThumnailNullImg = styled.div`
-  border-radius: ${cardBorderRadius} ${cardBorderRadius} 0 0;
+  border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
   background: #003366;
   height: 200px;
 `;
 
 export const BlogCardAuthorLine = styled.div`
+  align-items: center;
   color: #606060;
+  display: flex;
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 12px;
+  justify-content: space-between;
+  padding-bottom: 6px;
   width: 100%;
+`;
+
+//clickable cards
+export const CardClickable = styled(Link).attrs({
+  className: 'cardClickable',
+})`
+  border: 6px solid transparent;
+  border-radius: ${cardBorderRadius};
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  :hover,
+  :focus {
+    border-color: #fdb917;
+    box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
+    transition: 0.15s; /* These make the interaction less jumpy */
+    transition-timing-function: ease-in-out;
+  }
+  :focus {
+    outline: -webkit-focus-ring-color auto 6px !important;
+  }
+`;
+
+export const CardClickableDescription = styled.p.attrs({
+  className: 'cardClickableDescription',
+})`
+  background: #ffffff;
+  border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  padding: 24px;
+  text-align: left;
+`;
+
+export const CardClickableHeader = styled.h5.attrs({
+  className: 'cardClickableHeader',
+})`
+  border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
+  margin: 0;
 `;
 
 export const CardStyled = styled(Card).attrs({
@@ -163,59 +207,83 @@ export const CardTitle = styled.h5.attrs({
   }
 `;
 
-//community cards
-export const CommunityCardDescription = styled.p.attrs({
-  className: 'cardHorizontalText',
+//common components cards
+export const CommonComponentCardStyled = styled(CardClickable).attrs({
+  className: 'commonComponentCard',
+})``;
+
+export const CommonComponentCardHeader = styled(CardClickableHeader).attrs({
+  className: 'commonComponentCardHeader',
 })`
   background: #ffffff;
-  border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
-  height: 100%;
-  margin: 0;
-  overflow: hidden;
-  padding: 24px;
-  text-align: left;
+  padding: 24px 24px 0;
 `;
 
-export const CommunityCardHeader = styled.h5.attrs({
-  className: 'cardHorizontalText',
+export const CommonComponentCardDescription = styled(
+  CardClickableDescription
+).attrs({
+  className: 'commonComponentCardDescription',
+})`
+  padding: 40px 24px 24px;
+`;
+
+export const CommonComponentCardTitle = styled(CardTitle).attrs({
+  className: 'commonComponentCardTitle',
+})`
+  font-size: 26px;
+  margin-bottom: 0;
+`;
+
+//community cards
+export const CommunityCardDescription = styled(CardClickableDescription).attrs({
+  className: 'communityCardDescription',
+})``;
+
+export const CommunityCardHeader = styled(CardClickableHeader).attrs({
+  className: 'communityCardHeader',
 })`
   background: #003366;
-  border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
   color: #ffffff;
   font-weight: 700;
   font-size: 21px;
+  padding: 24px;
+`;
+
+export const CommunityCardStyled = styled(CardClickable).attrs({
+  className: 'communityCard',
+})``;
+
+//blog cards
+export const BlogCardHeader = styled(CardClickableHeader).attrs({
+  className: 'blogCardHeader',
+})`
+  background: #ffffff;
+  border-radius: 0;
   height: fit-content;
   margin: 0;
-  padding: 24px;
+  max-height: 100%;
+  padding: 24px 24px 0;
   text-align: left;
 `;
 
-export const CommunityCardStyled = styled(Link).attrs({
-  className: 'cardRound',
+export const BlogCardTitle = styled(CardTitle).attrs({
+  className: 'blogCardTitle',
 })`
-  border: 6px solid transparent;
-  border-radius: ${cardBorderRadius};
-  height: 100%;
-  margin-bottom: 20px;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  :hover,
-  :focus {
-    border-color: #fdb917;
-    box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
-    transition: 0.15s; /* These make the interaction less jumpy */
-    transition-timing-function: ease-in-out;
-  }
-  :focus {
-    outline: -webkit-focus-ring-color auto 6px !important;
-  }
+  font-size: 26px;
+  margin-bottom: 0;
 `;
 
-export const BlogCardStyled = styled(CommunityCardStyled)`
-  background: white;
-  display: block;
+export const BlogCardDescription = styled(CardClickableDescription).attrs({
+  className: 'blogCardDescription',
+})`
+  border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
+  margin-bottom: 0;
+  padding: 16px 24px 32px;
 `;
+
+export const BlogCardStyled = styled(CardClickable).attrs({
+  className: 'blogCard',
+})``;
 
 export const Icon = styled.img.attrs({
   className: 'icon',

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -208,27 +208,25 @@ export const CardTitle = styled.h5.attrs({
 `;
 
 //common components cards
-export const CommonComponentCardStyled = styled(CardClickable).attrs({
-  className: 'commonComponentCard',
+export const CoCoCardStyled = styled(CardClickable).attrs({
+  className: 'coCoCard',
 })``;
 
-export const CommonComponentCardHeader = styled(CardClickableHeader).attrs({
-  className: 'commonComponentCardHeader',
+export const CoCoCardHeader = styled(CardClickableHeader).attrs({
+  className: 'coCoCardHeader',
 })`
   background: #ffffff;
   padding: 24px 24px 0;
 `;
 
-export const CommonComponentCardDescription = styled(
-  CardClickableDescription
-).attrs({
-  className: 'commonComponentCardDescription',
+export const CoCoCardDescription = styled(CardClickableDescription).attrs({
+  className: 'coCoCardDescription',
 })`
   padding: 40px 24px 24px;
 `;
 
-export const CommonComponentCardTitle = styled(CardTitle).attrs({
-  className: 'commonComponentCardTitle',
+export const CoCoCardTitle = styled(CardTitle).attrs({
+  className: 'coCoCardTitle',
 })`
   font-size: 26px;
   margin-bottom: 0;


### PR DESCRIPTION
This PR addresses these issues:

- Applies the styling for clickable cards established on Communities to Blog and Common Components cards (#850) 
- Cleans up the border corners (#867)
- Adjusts spacing on Common Components cards to match wireframe (#868)
- Adjusts details of Blog card styling to match wireframe (#742)