### PR TITLE
restrict branch deployments come from, change check on delete script

### DIFF
--- a/.github/workflows/deploy-react-to-dev.yaml
+++ b/.github/workflows/deploy-react-to-dev.yaml
@@ -1,5 +1,8 @@
 name: Deploy React To Dev
-on: [pull_request]
+on: 
+  pull_request:
+    branches:
+      - develop
 #   pull_request:
 #     paths:
 #       - 'react-frontend/**'

--- a/ansible/tasks/delete_images.yaml
+++ b/ansible/tasks/delete_images.yaml
@@ -1,7 +1,7 @@
 ---  
   - name: Delete buildconfig for {{ react_infra_name }} of PR {{ PR }} in {{ image_namespace }} namespace
     shell: >
-      oc delete -n "{{ image_namespace }}" buildconfig --selector pr={{ PR }}
+      oc delete -n "{{ image_namespace }}" buildconfig --selector version=pr-{{ PR }}
   - name: Delete build for {{ react_infra_name }} of PR {{ PR }} in {{ image_namespace }} namespace
     shell: >
-      oc delete -n "{{ image_namespace }}" build --selector pr={{ PR }}
+      oc delete -n "{{ image_namespace }}" build --selector version=pr-{{ PR }}


### PR DESCRIPTION
- This pr has the deletion script target the version name rather than the PR so that it won't delete the test and prod bc by accident.
- This also prevent a dev deployment from building when a pr is opened against master