### PR TITLE
881 clickable cards

### DIFF
--- a/react-frontend/src/components/Blog/blogCard.js
+++ b/react-frontend/src/components/Blog/blogCard.js
@@ -60,7 +60,7 @@ function BlogCard({
             <span>{author}</span>
           </div>
           <div>
-            {dateFormat(date, 'mmm d,yyyy')}
+            {dateFormat(date, 'mmm d, yyyy')}
           </div>
         </BlogCardAuthorLine>
         <BlogCardTitle data-testid="title">

--- a/react-frontend/src/components/Blog/blogCard.js
+++ b/react-frontend/src/components/Blog/blogCard.js
@@ -45,11 +45,11 @@ function BlogCard({
   return (
     <BlogCardStyled to={`/blog/${uid}`}>
       {coverImgSrc ? (
-        <div style={{ height: '200px' }}>
+        <div>
           <BlogCardThumnail src={coverImgSrc} data-testid="thumbnail" />
         </div>
       ) : (
-        <div style={{ height: '200px' }}>
+        <div>
           <BlogCardThumnailNullImg />
         </div>
       )}

--- a/react-frontend/src/components/Blog/blogCard.js
+++ b/react-frontend/src/components/Blog/blogCard.js
@@ -24,7 +24,7 @@ function AuthorIcon({ url }) {
           height: '24px',
           verticalAlign: 'middle',
           width: '24px',
-          marginLeft: '4px',
+          marginRight: '6px',
         }}
         data-testid="authorImage"
       />
@@ -45,17 +45,23 @@ function BlogCard({
   return (
     <BlogCardStyled to={`/blog/${uid}`}>
       {coverImgSrc ? (
-        <BlogCardThumnail src={coverImgSrc} data-testid="thumbnail" />
+        <div>
+          <BlogCardThumnail src={coverImgSrc} data-testid="thumbnail" />
+        </div>
       ) : (
-        <BlogCardThumnailNullImg />
+        <div>
+          <BlogCardThumnailNullImg />
+        </div>
       )}
       <BlogCardBody>
         <BlogCardAuthorLine>
-          <span>{author}</span>
-          <AuthorIcon url={authImg} />
-          <span style={{ float: 'right' }}>
+          <div>
+            <AuthorIcon url={authImg}/>
+            <span>{author}</span>
+          </div>
+          <div>
             {dateFormat(date, 'mmm d,yyyy')}
-          </span>
+          </div>
         </BlogCardAuthorLine>
         <BlogCardTitle data-testid="title">
           {title}

--- a/react-frontend/src/components/Blog/blogCard.js
+++ b/react-frontend/src/components/Blog/blogCard.js
@@ -45,27 +45,23 @@ function BlogCard({
   return (
     <BlogCardStyled to={`/blog/${uid}`}>
       {coverImgSrc ? (
-        <div>
+        <div style={{ height: '200px' }}>
           <BlogCardThumnail src={coverImgSrc} data-testid="thumbnail" />
         </div>
       ) : (
-        <div>
+        <div style={{ height: '200px' }}>
           <BlogCardThumnailNullImg />
         </div>
       )}
       <BlogCardBody>
         <BlogCardAuthorLine>
           <div>
-            <AuthorIcon url={authImg}/>
+            <AuthorIcon url={authImg} />
             <span>{author}</span>
           </div>
-          <div>
-            {dateFormat(date, 'mmm d, yyyy')}
-          </div>
+          <div>{dateFormat(date, 'mmm d, yyyy')}</div>
         </BlogCardAuthorLine>
-        <BlogCardTitle data-testid="title">
-          {title}
-        </BlogCardTitle>
+        <BlogCardTitle data-testid="title">{title}</BlogCardTitle>
         <BlogCardDescription data-testid="description">
           {description}
         </BlogCardDescription>

--- a/react-frontend/src/components/Blog/blogCard.js
+++ b/react-frontend/src/components/Blog/blogCard.js
@@ -2,12 +2,13 @@ import React from 'react';
 import dateFormat from 'dateformat';
 import 'antd/dist/antd.css';
 import {
+  BlogCardAuthorLine,
+  BlogCardBody,
+  BlogCardDescription,
+  BlogCardStyled,
   BlogCardThumnail,
   BlogCardThumnailNullImg,
-  BlogCardAuthorLine,
-  BlogCardStyled,
-  CardTitle,
-  CardDescription,
+  BlogCardTitle,
   CommunityCardStyled,
 } from '../StyleComponents/card';
 
@@ -48,7 +49,7 @@ function BlogCard({
       ) : (
         <BlogCardThumnailNullImg />
       )}
-      <div style={{ padding: '24px' }}>
+      <BlogCardBody>
         <BlogCardAuthorLine>
           <span>{author}</span>
           <AuthorIcon url={authImg} />
@@ -56,16 +57,13 @@ function BlogCard({
             {dateFormat(date, 'mmm d,yyyy')}
           </span>
         </BlogCardAuthorLine>
-        <CardTitle
-          style={{ fontSize: '25.92px', clear: 'both' }}
-          data-testid="title"
-        >
+        <BlogCardTitle data-testid="title">
           {title}
-        </CardTitle>
-        <CardDescription data-testid="description">
+        </BlogCardTitle>
+        <BlogCardDescription data-testid="description">
           {description}
-        </CardDescription>
-      </div>
+        </BlogCardDescription>
+      </BlogCardBody>
     </BlogCardStyled>
   );
 }

--- a/react-frontend/src/components/CoCos/__snapshots__/coCoCards.test.js.snap
+++ b/react-frontend/src/components/CoCos/__snapshots__/coCoCards.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Renders without crashing if not props are passed in 1`] = `
 <div
-  className="sc-bYoCmx sc-jJoQpE hPizzx exVZUJ horizontalAlignment contentBlockContainer container"
+  className="sc-iUKrWq sc-cTApHj llGXyk kAkwDa horizontalAlignment contentBlockContainer container"
   id="standards"
 >
   <div
@@ -12,7 +12,7 @@ exports[`Renders without crashing if not props are passed in 1`] = `
       className="col-sm-12"
     >
       <h2
-        className="sc-jgrIVw kNhBHE resourceHeading"
+        className="sc-gGCCur UyWOY resourceHeading"
       >
         Explore
       </h2>
@@ -28,17 +28,17 @@ exports[`Renders without crashing if not props are passed in 1`] = `
       className="col-sm-12"
     >
       <h2
-        className="sc-jgrIVw kNhBHE resourceHeading"
+        className="sc-gGCCur UyWOY resourceHeading"
       >
         Support
       </h2>
       <p
-        className="sc-evcjBb iSVMOy digitalParagraph"
+        className="sc-kYHenr kozwur digitalParagraph"
       >
         Contact the Common Components team:
          
         <a
-          className="sc-jQrCkL fZOdkh externalLink"
+          className="sc-gIDmry dqBYPk externalLink"
           href="mailto:digital.government@gov.bc.ca"
         >
           Digital.Government@gov.bc.ca

--- a/react-frontend/src/components/CoCos/coCoCard.js
+++ b/react-frontend/src/components/CoCos/coCoCard.js
@@ -5,9 +5,10 @@ import { Link } from 'react-router-dom';
 
 import { Badge, BadgeWrapper } from '../StyleComponents/badge';
 import {
-  CardTitle,
-  CardDescription,
-  CardStyled,
+  CoCoCardTitle,
+  CoCoCardDescription,
+  CoCoCardHeader,
+  CoCoCardStyled,
   Icon,
   IconCol,
 } from '../StyleComponents/card';
@@ -79,73 +80,73 @@ function CoCoCard({
   uid,
 }) {
   return (
-    <Link to={`/common-components/${uid}`}>
-      <CardStyled>
+    <CoCoCardStyled to={`/common-components/${uid}`}>
+      <CoCoCardHeader>
         {Badges(status?.Status, status?.Maintenance, tags)}
-        <CardTitle data-testid="title" style={{ marginBottom: '0' }}>
+        <CoCoCardTitle data-testid="title" style={{ marginBottom: '0' }}>
           {title}
-        </CardTitle>
+        </CoCoCardTitle>
         <p>{nameAndMinistry}</p>
-        {/* This is commented out until a design desision is made */}
-        {/* <CardDescription
-          data-testid="description"
-          style={{ marginBottom: '40px' }}
-        > */}
-        <CardDescription data-testid="description">
-          {description}
-        </CardDescription>
-        {/* This is commented out until a design desision is made  */}
-        {/* <Row
-          start="xs"
-          style={{ bottom: '20px', position: 'absolute', width: '90%' }}
+      </CoCoCardHeader>
+      {/* This is commented out until a design desision is made */}
+      {/* <CardDescription
+        data-testid="description"
+        style={{ marginBottom: '40px' }}
+      > */}
+      <CoCoCardDescription data-testid="description">
+        {description}
+      </CoCoCardDescription>
+      {/* This is commented out until a design desision is made  */}
+      {/* <Row
+        start="xs"
+        style={{ bottom: '20px', position: 'absolute', width: '90%' }}
+      >
+        <IconCol
+          data-testid="cost"
+          xs={3}
+          title="Cost Structure"
+          style={{ paddingLeft: '0' }}
         >
+          <Row center="xs" style={{ height: '18px' }}>
+            <Icon src={priceIcon} />
+          </Row>
+          <Row center="xs">{cost}</Row>
+        </IconCol>
+        {numberOfUsers && (
           <IconCol
-            data-testid="cost"
+            data-testid="user-count"
             xs={3}
-            title="Cost Structure"
-            style={{ paddingLeft: '0' }}
+            title={'Number of Teams Using CoCo'}
           >
             <Row center="xs" style={{ height: '18px' }}>
-              <Icon src={priceIcon} />
+              <Icon src={peopleIcon} style={{ paddingRight: '2px' }} />
+              {numberOfUsers}
             </Row>
-            <Row center="xs">{cost}</Row>
+            <Row center="xs">Teams</Row>
           </IconCol>
-          {numberOfUsers && (
-            <IconCol
-              data-testid="user-count"
-              xs={3}
-              title={'Number of Teams Using CoCo'}
-            >
-              <Row center="xs" style={{ height: '18px' }}>
-                <Icon src={peopleIcon} style={{ paddingRight: '2px' }} />
-                {numberOfUsers}
-              </Row>
-              <Row center="xs">Teams</Row>
-            </IconCol>
-          )}
-          <IconCol
-            data-testid="onboarding-time"
-            xs={3}
-            title="Estimate of Onboarding Time"
-          >
-            <Row center="xs" style={{ height: '18px' }}>
-              <Icon src={clockIcon} />
-            </Row>
-            <Row center="xs">{onboardingTime}</Row>
-          </IconCol>
-          <IconCol
-            data-testid="support-schedule"
-            xs={3}
-            title="Support Availability"
-          >
-            <Row center="xs" style={{ height: '18px' }}>
-              <Icon src={assistantIcon} />
-            </Row>
-            <Row center="xs">{supportStructureObj[supportSchedule]}</Row>
-          </IconCol>
-        </Row> */}
-      </CardStyled>
-    </Link>
+        )}
+        <IconCol
+          data-testid="onboarding-time"
+          xs={3}
+          title="Estimate of Onboarding Time"
+        >
+          <Row center="xs" style={{ height: '18px' }}>
+            <Icon src={clockIcon} />
+          </Row>
+          <Row center="xs">{onboardingTime}</Row>
+        </IconCol>
+        <IconCol
+          data-testid="support-schedule"
+          xs={3}
+          title="Support Availability"
+        >
+          <Row center="xs" style={{ height: '18px' }}>
+            <Icon src={assistantIcon} />
+          </Row>
+          <Row center="xs">{supportStructureObj[supportSchedule]}</Row>
+        </IconCol>
+      </Row> */}
+    </CoCoCardStyled>
   );
 }
 

--- a/react-frontend/src/components/DigitalPrinciples/digitalPrinciples.js
+++ b/react-frontend/src/components/DigitalPrinciples/digitalPrinciples.js
@@ -173,7 +173,7 @@ function DigitalPrinciples() {
           <hr></hr>
           <p>
             <em>
-              These Principles are being developed in the open on GitHub. If you
+              These Principles were developed in the open on GitHub. If you
               would like to comment,{' '}
               <HrefLink
                 href={digitalPrincipleUrls.gitHub}
@@ -183,8 +183,8 @@ function DigitalPrinciples() {
                 visit the GitHub repository
               </HrefLink>{' '}
               and open an Issue, or send an email to{' '}
-              <HrefLink href="mailto:Daniel.Pizarro@gov.bc.ca">
-                Daniel.Pizarro@gov.bc.ca
+              <HrefLink href="mailto:amy.kirtay@gov.bc.ca">
+                Amy.Kirtay@gov.bc.ca
               </HrefLink>
               .
             </em>

--- a/react-frontend/src/components/HostingOptions/__snapshots__/hostingOptions.test.js.snap
+++ b/react-frontend/src/components/HostingOptions/__snapshots__/hostingOptions.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <div>
   <div
-    className="sc-gGCCur sc-dvQbkV bDMVfk kpPukW horizontalAlignment pageContainer container"
+    className="sc-hmjpBu sc-dtMiey hwLXKX unuLi horizontalAlignment pageContainer container"
   >
     <div
       className="row middle-xs"
@@ -12,7 +12,7 @@ exports[`renders correctly 1`] = `
         className="col-xs-12 col-lg-8"
       >
         <h1
-          className="sc-eLwHGX gHEwfk"
+          className="sc-GEcJY buFiZz"
         >
           Hosting Options
         </h1>
@@ -27,7 +27,7 @@ exports[`renders correctly 1`] = `
             A modern web-based application? Use
              
             <a
-              className="sc-khQdMy cHHQIT"
+              className="sc-ehCIER fbHnsV"
               onClick={[Function]}
             >
               containers
@@ -37,7 +37,7 @@ exports[`renders correctly 1`] = `
             Commercial off-the-shelf software? Use
              
             <a
-              className="sc-khQdMy cHHQIT"
+              className="sc-ehCIER fbHnsV"
               onClick={[Function]}
             >
               virtual servers
@@ -47,7 +47,7 @@ exports[`renders correctly 1`] = `
             Big data warehouse for hosting and working with massive amounts of data? Use
              
             <a
-              className="sc-khQdMy cHHQIT"
+              className="sc-ehCIER fbHnsV"
               onClick={[Function]}
             >
               physical servers
@@ -58,7 +58,7 @@ exports[`renders correctly 1`] = `
           The B.C. government has several hosting options, which are further described below. If you’re not sure, contact
            
           <a
-            className="sc-dPiKHq iSJcXK externalLink"
+            className="sc-jeqYYF zjmip externalLink"
             href="mailto:CITZAS@gov.bc.ca"
           >
             CITZAS@gov.bc.ca
@@ -71,7 +71,7 @@ exports[`renders correctly 1`] = `
         className="col-xs-12 col-lg-4"
       >
         <div
-          className="ant-card ant-card-bordered sc-hKwCoD gKhahH cardRound"
+          className="ant-card ant-card-bordered sc-hKwCoD fApqXv cardRound"
           data-testid="styled-card"
         >
           <div
@@ -92,7 +92,7 @@ exports[`renders correctly 1`] = `
               className="sc-crHlIS guojQY cardLink"
             >
               <a
-                className="sc-bBHHQT kcwmSh externalLink"
+                className="sc-eJwXpk hGQaAH externalLink"
                 href="Hosting-and-Application-Development-Strategy.pdf"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -136,12 +136,12 @@ exports[`renders correctly 1`] = `
           name="containers"
         />
         <h2
-          className="sc-bTfYlY hSCyFG heading"
+          className="sc-gsNhcj elzHSl heading"
         >
           Containers 
         </h2>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Overview
         </h4>
@@ -149,7 +149,7 @@ exports[`renders correctly 1`] = `
           Containers provide a way for several digital services to share a single operating system. Digital teams can focus their efforts on the service they’re providing rather than installing or maintaining the infrastructure. Containers also support the idea of “infrastructure as code”, which means that a service can increase or decrease the resources it requires based on demand or even launch new instances of itself if something goes wrong.
         </p>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Pros 
         </h4>
@@ -169,7 +169,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Cons 
         </h4>
@@ -191,7 +191,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Recommendation
         </h4>
@@ -200,7 +200,7 @@ exports[`renders correctly 1`] = `
            
         </p>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           How to onboard 
         </h4>
@@ -208,7 +208,7 @@ exports[`renders correctly 1`] = `
           The container hosting options for the B.C. government are evolving and include public and private cloud platforms. Contact the
            
           <a
-            className="sc-dPiKHq iSJcXK externalLink"
+            className="sc-jeqYYF zjmip externalLink"
             href="mailto:pathfinder@gov.bc.ca"
           >
             platform services team
@@ -221,12 +221,12 @@ exports[`renders correctly 1`] = `
           name="virtualServers"
         />
         <h2
-          className="sc-bTfYlY hSCyFG heading"
+          className="sc-gsNhcj elzHSl heading"
         >
           Virtual servers 
         </h2>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Overview
         </h4>
@@ -234,7 +234,7 @@ exports[`renders correctly 1`] = `
           A virtual server provides a way for several digital services to share a single physical server. Virtual servers are an established hosting option for the B.C. government. They are more expensive than containers and require additional maintenance.
         </p>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Pros 
         </h4>
@@ -250,7 +250,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Cons 
         </h4>
@@ -260,7 +260,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Recommendation
         </h4>
@@ -269,7 +269,7 @@ exports[`renders correctly 1`] = `
            
         </p>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           How to onboard
         </h4>
@@ -277,7 +277,7 @@ exports[`renders correctly 1`] = `
           The B.C. government offers virtual servers in its data centers via the
            
           <a
-            className="sc-dPiKHq iSJcXK externalLink"
+            className="sc-jeqYYF zjmip externalLink"
             href="https://ssbc-client.gov.bc.ca/order/istore.htm"
           >
             iStore order management tool
@@ -310,7 +310,7 @@ exports[`renders correctly 1`] = `
           Virtual servers are also available to early adopters via the
            
           <a
-            className="sc-dPiKHq iSJcXK externalLink"
+            className="sc-jeqYYF zjmip externalLink"
             href="mailto:Cloud.Questions@gov.bc.ca"
           >
             Cloud Pathfinder team
@@ -322,12 +322,12 @@ exports[`renders correctly 1`] = `
           name="physicalServers"
         />
         <h2
-          className="sc-bTfYlY hSCyFG heading"
+          className="sc-gsNhcj elzHSl heading"
         >
           Physical servers
         </h2>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Overview
         </h4>
@@ -335,7 +335,7 @@ exports[`renders correctly 1`] = `
           Physical servers represent the oldest hosting option currently available for onboarding for B.C. government teams. When using physical servers, teams need to be mindful that there is significant maintenance overhead.
         </p>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Pros 
         </h4>
@@ -348,7 +348,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Cons 
         </h4>
@@ -361,7 +361,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           Recommendation
         </h4>
@@ -369,7 +369,7 @@ exports[`renders correctly 1`] = `
           Physical servers are not recommended.
         </p>
         <h4
-          className="sc-hOGjNT iVOdQb subSubHeading"
+          className="sc-eGRTUG kkDsPl subSubHeading"
         >
           How to onboard
         </h4>
@@ -377,7 +377,7 @@ exports[`renders correctly 1`] = `
           The B.C. government offers physical servers in its data centers via the
            
           <a
-            className="sc-dPiKHq iSJcXK externalLink"
+            className="sc-jeqYYF zjmip externalLink"
             href="https://ssbc-client.gov.bc.ca/order/istore.htm"
           >
             iStore order management tool

--- a/react-frontend/src/components/Learning/__snapshots__/eventCard.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/eventCard.test.js.snap
@@ -2,15 +2,15 @@
 
 exports[`renders correctly 1`] = `
 <div
-  className="sc-ieebsP bIJOHE cardRound"
+  className="sc-iJKOzS fudOnS cardRound"
 >
   <img
-    className="sc-dJjZJu cpOIo"
+    className="sc-giYgFv icSVfd"
     data-testid="thumbnail"
     src="https://testIMG.com"
   />
   <div
-    className="sc-dlVyqM dDrPTL"
+    className="sc-bYoCmx gDuUUi"
   >
     <h5
       className="sc-egiSv kfuvTV cardTitle"
@@ -30,7 +30,7 @@ exports[`renders correctly 1`] = `
       A great description
     </p>
     <a
-      className="sc-bBHHQT kcwmSh externalLink"
+      className="sc-eJwXpk hGQaAH externalLink"
       href="https://test.com"
       rel="noopener noreferrer"
       style={

--- a/react-frontend/src/components/Learning/__snapshots__/events.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/events.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <div
-  className="sc-gGCCur sc-GamvQ bDMVfk eMGnXi horizontalAlignment contentBlockContainer container"
+  className="sc-hmjpBu sc-kHOZQx hwLXKX oA-DQh horizontalAlignment contentBlockContainer container"
   id="standards"
 >
   <div
@@ -12,7 +12,7 @@ exports[`renders correctly 1`] = `
       className="col-sm-12"
     >
       <h2
-        className="sc-bTfYlY hSCyFG heading"
+        className="sc-gsNhcj elzHSl heading"
       >
         Events
       </h2>

--- a/react-frontend/src/components/Learning/__snapshots__/learning.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/learning.test.js.snap
@@ -13,15 +13,15 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-md-6"
       >
         <div
-          className="sc-bilypg xYOXV sideImageText"
+          className="sc-jWUzTF leYYRU sideImageText"
         >
           <h1
-            className="sc-eGPWxh iOaPFZ bannerTitle"
+            className="sc-eFehXo jpSmlh bannerTitle"
           >
             Learning
           </h1>
           <div
-            className="sc-hAcGfq eRfwaq subTitle"
+            className="sc-fmBDoT ZXmWC subTitle"
           >
              
             Understand and adopt new approaches to teamwork and technology.
@@ -34,7 +34,7 @@ exports[`renders correctly 1`] = `
       >
         <img
           alt=""
-          className="sc-uoixf PDyrl sideImage"
+          className="sc-FNZbm gLNNNt sideImage"
         />
       </div>
     </div>
@@ -135,7 +135,7 @@ exports[`renders correctly 1`] = `
         >
           <img
             alt=""
-            className="sc-brSwnh erfstK sideImage"
+            className="sc-eGPWxh dyvDcV sideImage"
           />
         </div>
       </div>
@@ -169,7 +169,7 @@ exports[`renders correctly 1`] = `
             Recent Episodes
           </h3>
           <a
-            className="sc-dtMiey jeYPik externalLink"
+            className="sc-ctqRej fteQIH externalLink"
             href="https://bcdevexchange.libsyn.com/"
             rel="noopener noreferrer"
             style={
@@ -218,7 +218,7 @@ exports[`renders correctly 1`] = `
         }
       >
         <div
-          className="ant-collapse-item sc-fHeRAw ceByPV PanelStyled"
+          className="ant-collapse-item sc-xiKGw jTkApA PanelStyled"
         >
           <div
             aria-expanded={false}

--- a/react-frontend/src/components/Resources/__snapshots__/resources.test.js.snap
+++ b/react-frontend/src/components/Resources/__snapshots__/resources.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <div>
   <div
-    className="sc-gGCCur sc-clIAKW bDMVfk jtfrJe horizontalAlignment bannerCenterText container"
+    className="sc-hmjpBu sc-eLwHGX hwLXKX eryfvo horizontalAlignment bannerCenterText container"
     id="main-content-anchor"
   >
     <div
@@ -13,15 +13,15 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-md-6"
       >
         <div
-          className="sc-dkYRiW YmfyG sideImageText"
+          className="sc-jHkVfK htRvFC sideImageText"
         >
           <h1
-            className="sc-XxOsz jhUvdq bannerTitle"
+            className="sc-bQtJOP cAwshC bannerTitle"
           >
             Resources
           </h1>
           <div
-            className="sc-ilftOa bGftwl subTitle"
+            className="sc-fXEqXD iyAbAK subTitle"
           >
              
             Policy, standards, guides, and tools you can use right now to deliver excellent digital services.
@@ -34,13 +34,13 @@ exports[`renders correctly 1`] = `
       >
         <img
           alt=""
-          className="sc-dtDOJZ duVzsb sideImage"
+          className="sc-dVNiOx bQxqfS sideImage"
         />
       </div>
     </div>
   </div>
   <div
-    className="sc-gGCCur sc-GamvQ bDMVfk eMGnXi horizontalAlignment contentBlockContainer container"
+    className="sc-hmjpBu sc-kHOZQx hwLXKX oA-DQh horizontalAlignment contentBlockContainer container"
     id="standards"
   >
     <div
@@ -50,7 +50,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12"
       >
         <h2
-          className="sc-GEcJY egWSaN resourceHeading"
+          className="sc-dtDOJZ iwPAsw resourceHeading"
         >
           Standards & Policy
         </h2>
@@ -63,7 +63,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-md-6"
       >
         <div
-          className="ant-card ant-card-bordered sc-hKwCoD gKhahH cardRound"
+          className="ant-card ant-card-bordered sc-hKwCoD fApqXv cardRound"
           data-testid="styled-card"
         >
           <div
@@ -84,7 +84,7 @@ exports[`renders correctly 1`] = `
               className="sc-crHlIS guojQY cardLink"
             >
               <a
-                className="sc-cNKpQo bjtEtE internalLink"
+                className="sc-nVjpj bWXCMc internalLink"
                 href="/resources/digital-principles"
                 onClick={[Function]}
               >
@@ -98,7 +98,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-md-6"
       >
         <div
-          className="ant-card ant-card-bordered sc-hKwCoD gKhahH cardRound"
+          className="ant-card ant-card-bordered sc-hKwCoD fApqXv cardRound"
           data-testid="styled-card"
         >
           <div
@@ -119,7 +119,7 @@ exports[`renders correctly 1`] = `
               className="sc-crHlIS guojQY cardLink"
             >
               <a
-                className="sc-bBHHQT kcwmSh externalLink"
+                className="sc-eJwXpk hGQaAH externalLink"
                 href="https://www2.gov.bc.ca/gov/content?id=2A477231EF934E22B0FBC8C43A98B9D9"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -154,7 +154,7 @@ exports[`renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="sc-gGCCur sc-GamvQ bDMVfk eMGnXi horizontalAlignment contentBlockContainer container"
+    className="sc-hmjpBu sc-kHOZQx hwLXKX oA-DQh horizontalAlignment contentBlockContainer container"
     id="standards"
   >
     <div
@@ -164,19 +164,19 @@ exports[`renders correctly 1`] = `
         className="col-md-12 col-lg-4"
       >
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <h3
-            className="sc-gsNhcj dilNeG resourceSubHeading"
+            className="sc-dkYRiW hzLfDT resourceSubHeading"
           >
             Technical
           </h3>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=5D5C4759BC7E494AB9E8EDB7AD3D3D78"
             rel="noopener noreferrer"
             target="_blank"
@@ -206,10 +206,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=2AC548A48CD7445A9359AF7BB204B6F6"
             rel="noopener noreferrer"
             target="_blank"
@@ -239,10 +239,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=1AA28225F41347FE9F8D0B4F1733CEFE"
             rel="noopener noreferrer"
             target="_blank"
@@ -276,19 +276,19 @@ exports[`renders correctly 1`] = `
         className="col-md-12 col-lg-4"
       >
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <h3
-            className="sc-gsNhcj dilNeG resourceSubHeading"
+            className="sc-dkYRiW hzLfDT resourceSubHeading"
           >
             Privacy
           </h3>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=C962EFF559134B69A8A9ABB3C121D6C7"
             rel="noopener noreferrer"
             target="_blank"
@@ -318,10 +318,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=54A04E35FA854B298DECF17ABC94E943"
             rel="noopener noreferrer"
             target="_blank"
@@ -351,10 +351,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=CFA561FF833D42B68FDD9A818ECAFFBE"
             rel="noopener noreferrer"
             target="_blank"
@@ -388,19 +388,19 @@ exports[`renders correctly 1`] = `
         className="col-md-12 col-lg-4"
       >
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <h3
-            className="sc-gsNhcj dilNeG resourceSubHeading"
+            className="sc-dkYRiW hzLfDT resourceSubHeading"
           >
             Security
           </h3>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=BB7D7F3938634BF2973BDE1A899FB755"
             rel="noopener noreferrer"
             target="_blank"
@@ -430,10 +430,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=7175C19B66564EA3A343AB8B668BEFC2"
             rel="noopener noreferrer"
             target="_blank"
@@ -466,7 +466,7 @@ exports[`renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="sc-gGCCur sc-GamvQ bDMVfk eMGnXi horizontalAlignment contentBlockContainer container"
+    className="sc-hmjpBu sc-kHOZQx hwLXKX oA-DQh horizontalAlignment contentBlockContainer container"
     id="guides"
   >
     <div
@@ -476,7 +476,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12"
       >
         <h2
-          className="sc-GEcJY egWSaN resourceHeading"
+          className="sc-dtDOJZ iwPAsw resourceHeading"
         >
           Guides
         </h2>
@@ -489,7 +489,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-md-6"
       >
         <div
-          className="ant-card ant-card-bordered sc-hKwCoD gKhahH cardRound"
+          className="ant-card ant-card-bordered sc-hKwCoD fApqXv cardRound"
           data-testid="styled-card"
         >
           <div
@@ -510,7 +510,7 @@ exports[`renders correctly 1`] = `
               className="sc-crHlIS guojQY cardLink"
             >
               <a
-                className="sc-cNKpQo bjtEtE internalLink"
+                className="sc-nVjpj bWXCMc internalLink"
                 href="/resources/hosting-options"
                 onClick={[Function]}
               >
@@ -524,7 +524,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-md-6"
       >
         <div
-          className="ant-card ant-card-bordered sc-hKwCoD gKhahH cardRound"
+          className="ant-card ant-card-bordered sc-hKwCoD fApqXv cardRound"
           data-testid="styled-card"
         >
           <div
@@ -545,7 +545,7 @@ exports[`renders correctly 1`] = `
               className="sc-crHlIS guojQY cardLink"
             >
               <a
-                className="sc-bBHHQT kcwmSh externalLink"
+                className="sc-eJwXpk hGQaAH externalLink"
                 href="https://github.com/bcgov/CITZ-IMB-playbook"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -580,7 +580,7 @@ exports[`renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="sc-gGCCur sc-GamvQ bDMVfk eMGnXi horizontalAlignment contentBlockContainer container"
+    className="sc-hmjpBu sc-kHOZQx hwLXKX oA-DQh horizontalAlignment contentBlockContainer container"
     id="forDesigners"
   >
     <div
@@ -590,19 +590,19 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-lg-6"
       >
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <h3
-            className="sc-gsNhcj dilNeG resourceSubHeading"
+            className="sc-dkYRiW hzLfDT resourceSubHeading"
           >
             For Designers
           </h3>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=EADC5FB4D3BE4A6DB71C35A64CFECDFC"
             rel="noopener noreferrer"
             target="_blank"
@@ -632,10 +632,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=81BBC6221D42401EBCE13D4D8945F3A3"
             rel="noopener noreferrer"
             target="_blank"
@@ -665,10 +665,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=D5D182EF4D9F42B5997CCB2029068B5E"
             rel="noopener noreferrer"
             target="_blank"
@@ -698,10 +698,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://bcgov.github.io/design-research-guide/"
             rel="noopener noreferrer"
             target="_blank"
@@ -731,10 +731,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://developer.gov.bc.ca/Design-System/About-the-Design-System"
             rel="noopener noreferrer"
             target="_blank"
@@ -764,10 +764,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=250C67AD0B954DB9B0549EED6C36BDEF"
             rel="noopener noreferrer"
             target="_blank"
@@ -797,10 +797,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=A9B5158C5DB5499A83BD046E94CBCBB1"
             rel="noopener noreferrer"
             target="_blank"
@@ -830,10 +830,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=B990ECA6DAB94CD0BE2C1AE7BD439ADC"
             rel="noopener noreferrer"
             target="_blank"
@@ -863,10 +863,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=A9801C7B52CE481BBD36CAD87C297142"
             rel="noopener noreferrer"
             target="_blank"
@@ -896,10 +896,10 @@ exports[`renders correctly 1`] = `
           </a>
         </div>
         <div
-          className="sc-eJwXpk cYlBcr row"
+          className="sc-dvQbkV jIqPUg row"
         >
           <a
-            className="sc-bBHHQT kcwmSh externalLink"
+            className="sc-eJwXpk hGQaAH externalLink"
             href="https://www2.gov.bc.ca/gov/content?id=14FD003042FC422182796E84A6C343C9"
             rel="noopener noreferrer"
             target="_blank"
@@ -933,14 +933,14 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-lg-6"
       >
         <div
-          className="sc-kfPtPH ehFDCR cardRound"
+          className="sc-kLwgWK dvnVqf cardRound"
         >
           <img
-            className="sc-fKVsgm kWOTXr"
+            className="sc-ikJzcn lkuAqi"
             data-testid="thumbnail"
           />
           <div
-            className="sc-bBHwJV ehjgOH"
+            className="sc-jJoQpE fkjRiz"
           >
             <h5
               className="sc-egiSv kfuvTV cardTitle"
@@ -960,7 +960,7 @@ exports[`renders correctly 1`] = `
               When you can’t meet with your coworkers or clients face-to-face, communicating with them by video can be the next best thing. There are many options available for video communication platforms or tools, many of which can also be used for instant messaging or chat, screen sharing and transferring files.
             </p>
             <a
-              className="sc-AjmZR gSDRqR internalLink"
+              className="sc-hiwReK ejbacx internalLink"
               href="/guides/communication-platforms"
               onClick={[Function]}
               style={
@@ -977,7 +977,7 @@ exports[`renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="sc-gGCCur sc-GamvQ bDMVfk eMGnXi horizontalAlignment contentBlockContainer container"
+    className="sc-hmjpBu sc-kHOZQx hwLXKX oA-DQh horizontalAlignment contentBlockContainer container"
     id="forDevelopers"
   >
     <div
@@ -987,7 +987,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12"
       >
         <h3
-          className="sc-gsNhcj dilNeG resourceSubHeading"
+          className="sc-dkYRiW hzLfDT resourceSubHeading"
         >
           For Developers
         </h3>
@@ -1000,7 +1000,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-md-6"
       >
         <div
-          className="ant-card ant-card-bordered sc-hKwCoD gKhahH cardRound"
+          className="ant-card ant-card-bordered sc-hKwCoD fApqXv cardRound"
           data-testid="styled-card"
         >
           <div
@@ -1021,7 +1021,7 @@ exports[`renders correctly 1`] = `
               className="sc-crHlIS guojQY cardLink"
             >
               <a
-                className="sc-bBHHQT kcwmSh externalLink"
+                className="sc-eJwXpk hGQaAH externalLink"
                 href="https://github.com/bcgov"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -1057,7 +1057,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12 col-md-6"
       >
         <div
-          className="ant-card ant-card-bordered sc-hKwCoD gKhahH cardRound"
+          className="ant-card ant-card-bordered sc-hKwCoD fApqXv cardRound"
           data-testid="styled-card"
         >
           <div
@@ -1078,7 +1078,7 @@ exports[`renders correctly 1`] = `
               className="sc-crHlIS guojQY cardLink"
             >
               <a
-                className="sc-bBHHQT kcwmSh externalLink"
+                className="sc-eJwXpk hGQaAH externalLink"
                 href="https://developer.gov.bc.ca/"
                 rel="noopener noreferrer"
                 target="_blank"

--- a/react-frontend/src/components/StyleComponents/badge.js
+++ b/react-frontend/src/components/StyleComponents/badge.js
@@ -37,5 +37,5 @@ export const BadgeWrapper = styled.div.attrs({
 })`
   display: flex;
   flex-wrap: wrap;
-  padding-bottom: 18px;
+  padding-bottom: 40px;
 `;

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -263,23 +263,15 @@ export const BlogCardStyled = styled(CardClickable).attrs({
 
 export const BlogCardThumnail = styled.img`
   border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
-  height: 100%;
+  height: 200px;
   object-fit: cover;
   width: 100%;
-  -webkit-backface-visibility: hidden;
-  -ms-transform: translateZ(0); /* IE 9 */
-  -webkit-transform: translateZ(0); /* Chrome, Safari, Opera */
-  transform: translateZ(0);
 `;
 
 export const BlogCardThumnailNullImg = styled.div`
   border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
   background: #003366;
   height: 200px;
-  -webkit-backface-visibility: hidden;
-  -ms-transform: translateZ(0); /* IE 9 */
-  -webkit-transform: translateZ(0); /* Chrome, Safari, Opera */
-  transform: translateZ(0);
 `;
 
 export const BlogCardTitle = styled(CardTitle).attrs({

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -6,49 +6,47 @@ import { Link } from 'react-router-dom';
 const cardBorderRadius = '21px';
 const cardBorderInsetRadius = '16px';
 
-
-
 //clickable cards
- export const CardClickable = styled(Link).attrs({
-   className: 'cardClickable',
- })`
-   border: 6px solid transparent;
-   border-radius: ${cardBorderRadius};
-   display: flex;
-   flex-direction: column;
-   height: 100%;
-   padding: 0;
-   :hover,
-   :focus {
-     border-color: #fdb917;
-     box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
-     cursor: pointer;
-     transition: 0.15s; /* These make the interaction less jumpy */
-     transition-timing-function: ease-in-out;
-   }
-   :focus {
-     outline: -webkit-focus-ring-color auto 6px !important;
-   }
- `;
+export const CardClickable = styled(Link).attrs({
+  className: 'cardClickable',
+})`
+  border: 6px solid transparent;
+  border-radius: ${cardBorderRadius};
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 0;
+  :hover,
+  :focus {
+    border-color: #fdb917;
+    box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
+    cursor: pointer;
+    transition: 0.15s; /* These make the interaction less jumpy */
+    transition-timing-function: ease-in-out;
+  }
+  :focus {
+    outline: -webkit-focus-ring-color auto 6px !important;
+  }
+`;
 
- export const CardClickableDescription = styled.p.attrs({
-   className: 'cardClickableDescription',
- })`
-   background: #ffffff;
-   border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
-   height: 100%;
-   margin: 0;
-   overflow: hidden;
-   padding: 24px;
-   text-align: left;
- `;
+export const CardClickableDescription = styled.p.attrs({
+  className: 'cardClickableDescription',
+})`
+  background: #ffffff;
+  border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  padding: 24px;
+  text-align: left;
+`;
 
- export const CardClickableHeader = styled.h5.attrs({
-   className: 'cardClickableHeader',
- })`
-   border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
-   margin: 0;
- `;
+export const CardClickableHeader = styled.h5.attrs({
+  className: 'cardClickableHeader',
+})`
+  border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
+  margin: 0;
+`;
 
 //basic styled cards (with link)
 export const CardStyled = styled(Card).attrs({
@@ -190,23 +188,23 @@ export const CardTitle = styled.h5.attrs({
 // common component cards
 export const CoCoCardDescription = styled(CardClickableDescription).attrs({
   className: 'coCoCardDescription',
- })`
+})`
   padding: 24px;
- `;
+`;
 
 export const CoCoCardHeader = styled(CardClickableHeader).attrs({
- className: 'coCoCardHeader',
+  className: 'coCoCardHeader',
 })`
   background: #fff;
   padding: 24px 24px 0;
 `;
 
 export const CoCoCardStyled = styled(CardClickable).attrs({
-   className: 'coCoCardStyled',
- })``;
+  className: 'coCoCardStyled',
+})``;
 
 export const CoCoCardTitle = styled(CardTitle).attrs({
- className: 'coCoCardTitle',
+  className: 'coCoCardTitle',
 })`
   font-size: 26px;
   margin-bottom: 0;
@@ -243,8 +241,7 @@ export const BlogCardAuthorLine = styled.div`
   width: 100%;
 `;
 
-export const BlogCardBody = styled.div.attrs({
-})`
+export const BlogCardBody = styled.div.attrs({})`
   background: #fff;
   border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
   height: 100%;
@@ -252,13 +249,13 @@ export const BlogCardBody = styled.div.attrs({
 `;
 
 export const BlogCardDescription = styled(CardClickableDescription).attrs({
-   className: 'blogCardDescription',
- })`
-   border-radius: 0;
-   height: fit-content;
-   margin-bottom: 0;
-   padding: 0;
- `;
+  className: 'blogCardDescription',
+})`
+  border-radius: 0;
+  height: fit-content;
+  margin-bottom: 0;
+  padding: 0;
+`;
 
 export const BlogCardStyled = styled(CardClickable).attrs({
   className: 'blogCard',

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -3,30 +3,54 @@ import { Card } from 'antd';
 import { Col } from 'react-flexbox-grid';
 import { Link } from 'react-router-dom';
 
-const cardBorderRadius = '25px';
-const cardBorderInsetRadius = '21px';
+const cardBorderRadius = '21px';
+const cardBorderInsetRadius = '18px';
 
-export const BlogCardThumnail = styled.img`
-  background: #003366;
-  border-radius: ${cardBorderRadius} ${cardBorderRadius} 0 0;
-  height: 200px;
-  object-fit: cover;
-  width: 100%;
-`;
 
-export const BlogCardThumnailNullImg = styled.div`
-  border-radius: ${cardBorderRadius} ${cardBorderRadius} 0 0;
-  background: #003366;
-  height: 200px;
-`;
 
-export const BlogCardAuthorLine = styled.div`
-  color: #606060;
-  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
-  font-size: 12px;
-  width: 100%;
-`;
+//clickable cards
+ export const CardClickable = styled(Link).attrs({
+   className: 'cardClickable',
+ })`
+   border: 6px solid transparent;
+   border-radius: ${cardBorderRadius};
+   display: flex;
+   flex-direction: column;
+   height: 100%;
+   padding: 0;
+   :hover,
+   :focus {
+     border-color: #fdb917;
+     box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
+     cursor: pointer;
+     transition: 0.15s; /* These make the interaction less jumpy */
+     transition-timing-function: ease-in-out;
+   }
+   :focus {
+     outline: -webkit-focus-ring-color auto 6px !important;
+   }
+ `;
 
+ export const CardClickableDescription = styled.p.attrs({
+   className: 'cardClickableDescription',
+ })`
+   background: #ffffff;
+   border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
+   height: 100%;
+   margin: 0;
+   overflow: hidden;
+   padding: 24px;
+   text-align: left;
+ `;
+
+ export const CardClickableHeader = styled.h5.attrs({
+   className: 'cardClickableHeader',
+ })`
+   border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
+   margin: 0;
+ `;
+
+//basic styled cards (with link)
 export const CardStyled = styled(Card).attrs({
   className: 'cardRound',
 })`
@@ -163,58 +187,101 @@ export const CardTitle = styled.h5.attrs({
   }
 `;
 
-//community cards
-export const CommunityCardDescription = styled.p.attrs({
-  className: 'cardHorizontalText',
+// common component cards
+export const CoCoCardDescription = styled(CardClickableDescription).attrs({
+  className: 'coCoCardDescription',
+ })`
+  padding: 40px 24px 24px;
+ `;
+
+export const CoCoCardHeader = styled(CardClickableHeader).attrs({
+ className: 'coCoCardHeader',
 })`
-  background: #ffffff;
-  border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
-  height: 100%;
-  margin: 0;
-  overflow: hidden;
-  padding: 24px;
-  text-align: left;
+  background: #fff;
+  padding: 24px 24px 0;
 `;
 
-export const CommunityCardHeader = styled.h5.attrs({
-  className: 'cardHorizontalText',
+export const CoCoCardStyled = styled(CardClickable).attrs({
+   className: 'coCoCardStyled',
+ })``;
+
+export const CoCoCardTitle = styled(CardTitle).attrs({
+ className: 'coCoCardTitle',
+})`
+  font-size: 26px;
+  margin-bottom: 0;
+`;
+
+//community cards
+export const CommunityCardDescription = styled(CardClickableDescription).attrs({
+  className: 'communityCardDescription',
+})``;
+
+export const CommunityCardHeader = styled(CardClickableHeader).attrs({
+  className: 'communityCardHeader',
 })`
   background: #003366;
-  border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
   color: #ffffff;
   font-weight: 700;
   font-size: 21px;
-  height: fit-content;
-  margin: 0;
   padding: 24px;
-  text-align: left;
 `;
 
-export const CommunityCardStyled = styled(Link).attrs({
-  className: 'cardRound',
-})`
-  border: 6px solid transparent;
-  border-radius: ${cardBorderRadius};
-  height: 100%;
-  margin-bottom: 20px;
-  width: 100%;
+export const CommunityCardStyled = styled(CardClickable).attrs({
+  className: 'communityCard',
+})``;
+
+//blog cards
+export const BlogCardAuthorLine = styled.div`
+  align-items: center;
+  color: #606060;
   display: flex;
-  flex-direction: column;
-  :hover,
-  :focus {
-    border-color: #fdb917;
-    box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
-    transition: 0.15s; /* These make the interaction less jumpy */
-    transition-timing-function: ease-in-out;
-  }
-  :focus {
-    outline: -webkit-focus-ring-color auto 6px !important;
-  }
+  font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
+  font-size: 12px;
+  justify-content: space-between;
+  padding-bottom: 6px;
+  width: 100%;
 `;
 
-export const BlogCardStyled = styled(CommunityCardStyled)`
-  background: white;
-  display: block;
+export const BlogCardBody = styled.div.attrs({
+})`
+  background: #fff;
+  border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
+  height: 100%;
+  padding: 24px;
+`;
+
+export const BlogCardDescription = styled(CardClickableDescription).attrs({
+   className: 'blogCardDescription',
+ })`
+   border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
+   height: fit-content;
+   margin-bottom: 0;
+   padding: 0;
+ `;
+
+export const BlogCardStyled = styled(CardClickable).attrs({
+  className: 'blogCard',
+})``;
+
+export const BlogCardThumnail = styled.img`
+  background: #003366;
+  border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
+  height: 200px;
+  object-fit: cover;
+  width: 100%;
+`;
+
+export const BlogCardThumnailNullImg = styled.div`
+  border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
+  background: #003366;
+  height: 200px;
+`;
+
+export const BlogCardTitle = styled(CardTitle).attrs({
+  className: 'blogCardTitle',
+})`
+  font-size: 24px;
 `;
 
 export const Icon = styled.img.attrs({

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -239,7 +239,7 @@ export const BlogCardAuthorLine = styled.div`
   font-family: BC Sans, Noto Sans, Verdana, Arial, sans-serif;
   font-size: 12px;
   justify-content: space-between;
-  padding-bottom: 6px;
+  padding-bottom: 12px;
   width: 100%;
 `;
 

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -262,17 +262,24 @@ export const BlogCardStyled = styled(CardClickable).attrs({
 })``;
 
 export const BlogCardThumnail = styled.img`
-  background: #003366;
   border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
-  height: 200px;
+  height: 100%;
   object-fit: cover;
   width: 100%;
+  -webkit-backface-visibility: hidden;
+  -ms-transform: translateZ(0); /* IE 9 */
+  -webkit-transform: translateZ(0); /* Chrome, Safari, Opera */
+  transform: translateZ(0);
 `;
 
 export const BlogCardThumnailNullImg = styled.div`
   border-radius: ${cardBorderInsetRadius} ${cardBorderInsetRadius} 0 0;
   background: #003366;
   height: 200px;
+  -webkit-backface-visibility: hidden;
+  -ms-transform: translateZ(0); /* IE 9 */
+  -webkit-transform: translateZ(0); /* Chrome, Safari, Opera */
+  transform: translateZ(0);
 `;
 
 export const BlogCardTitle = styled(CardTitle).attrs({

--- a/react-frontend/src/components/StyleComponents/card.js
+++ b/react-frontend/src/components/StyleComponents/card.js
@@ -4,7 +4,7 @@ import { Col } from 'react-flexbox-grid';
 import { Link } from 'react-router-dom';
 
 const cardBorderRadius = '21px';
-const cardBorderInsetRadius = '18px';
+const cardBorderInsetRadius = '16px';
 
 
 
@@ -191,7 +191,7 @@ export const CardTitle = styled.h5.attrs({
 export const CoCoCardDescription = styled(CardClickableDescription).attrs({
   className: 'coCoCardDescription',
  })`
-  padding: 40px 24px 24px;
+  padding: 24px;
  `;
 
 export const CoCoCardHeader = styled(CardClickableHeader).attrs({
@@ -254,7 +254,7 @@ export const BlogCardBody = styled.div.attrs({
 export const BlogCardDescription = styled(CardClickableDescription).attrs({
    className: 'blogCardDescription',
  })`
-   border-radius: 0 0 ${cardBorderInsetRadius} ${cardBorderInsetRadius};
+   border-radius: 0;
    height: fit-content;
    margin-bottom: 0;
    padding: 0;


### PR DESCRIPTION
This PR is a redo of #869 which, after merged, was discovered to contain an error that broke the link between CoCo cards and their corresponding detail page. I found the reason for that introduced bug and have redone the styling changes in this PR ensuring that the same issue does not occur. 

This PR: 

- Applies the styling for clickable cards established on Communities to the Blog and Common Components cards as well (#850) 
- Cleans up the rounded corners on cards (#867)
- Adjusts spacing on Common Components cards to match wireframe (#868)
- Adjusts details of Blog card styling to match wireframe (#742)

I also threw in this simple change: 
- Updates contact information on the Digital Principles page (#887)