### PR TITLE
Added a wait for build comple

### DIFF
--- a/ansible/build-react-for-test-prod.yaml
+++ b/ansible/build-react-for-test-prod.yaml
@@ -33,4 +33,8 @@
           - should_build
           - is_valid_author
 
+      - name: Wait for build to complete
+        include: ./tasks/wait_for_build_to_complete.yaml
+
+
 

--- a/ansible/build-react-for-test-prod.yaml
+++ b/ansible/build-react-for-test-prod.yaml
@@ -34,7 +34,7 @@
           - is_valid_author
 
       - name: Wait for build to complete
-        include: ./tasks/wait_for_build_to_complete.yaml
+        include: ./tasks/wait_for_build_to_complete_react.yaml
 
 
 

--- a/ansible/build-strapi-for-dev-test-prod.yaml
+++ b/ansible/build-strapi-for-dev-test-prod.yaml
@@ -33,4 +33,5 @@
           - should_build
           - is_valid_author
 
-
+      - name: Wait for build to complete
+        include: ./tasks/wait_for_build_to_complete_strapi.yaml

--- a/ansible/tasks/wait_for_build_to_complete.yaml
+++ b/ansible/tasks/wait_for_build_to_complete.yaml
@@ -2,7 +2,7 @@
   shell: >
     oc -n c0cce6-tools get build --selector build=digital-gov-frontend-test -o custom-columns=:status.phase --no-headers | tail -1
   register: build_status
-  until: (build_status == "Complete")
-  delay: 30
+  until: (build_status.stdout == "Complete")
+  delay: 60
   retries: 5
   ignore_errors: True

--- a/ansible/tasks/wait_for_build_to_complete.yaml
+++ b/ansible/tasks/wait_for_build_to_complete.yaml
@@ -1,0 +1,8 @@
+- name: Wait for "{{ kind }}" object {{ name }} pods to get into ready state in {{ namespace }} 
+  shell: >
+    oc -n c0cce6-tools get build --selector build=digital-gov-frontend-test -o custom-columns=:status.phase --no-headers | tail -1
+  register: build_status
+  until: (build_status == Complete)
+  delay: 30
+  retries: 5
+  ignore_errors: True

--- a/ansible/tasks/wait_for_build_to_complete.yaml
+++ b/ansible/tasks/wait_for_build_to_complete.yaml
@@ -5,4 +5,4 @@
   until: (build_status.stdout == "Complete")
   delay: 60
   retries: 5
-  ignore_errors: True
+  ignore_errors: False

--- a/ansible/tasks/wait_for_build_to_complete.yaml
+++ b/ansible/tasks/wait_for_build_to_complete.yaml
@@ -1,4 +1,4 @@
-- name: Wait for "{{ kind }}" object {{ name }} pods to get into ready state in {{ namespace }} 
+- name: Wait for {{ react_infra_name }}-{{ version }} build to complete in {{ tools_namespace }} 
   shell: >
     oc -n c0cce6-tools get build --selector build=digital-gov-frontend-test -o custom-columns=:status.phase --no-headers | tail -1
   register: build_status

--- a/ansible/tasks/wait_for_build_to_complete.yaml
+++ b/ansible/tasks/wait_for_build_to_complete.yaml
@@ -2,7 +2,7 @@
   shell: >
     oc -n c0cce6-tools get build --selector build=digital-gov-frontend-test -o custom-columns=:status.phase --no-headers | tail -1
   register: build_status
-  until: (build_status == Complete)
+  until: (build_status == "Complete")
   delay: 30
   retries: 5
   ignore_errors: True

--- a/ansible/tasks/wait_for_build_to_complete_react.yaml
+++ b/ansible/tasks/wait_for_build_to_complete_react.yaml
@@ -6,3 +6,4 @@
   delay: 60
   retries: 5
   ignore_errors: False
+  

--- a/ansible/tasks/wait_for_build_to_complete_react.yaml
+++ b/ansible/tasks/wait_for_build_to_complete_react.yaml
@@ -1,6 +1,6 @@
 - name: Wait for {{ react_infra_name }}-{{ version }} build to complete in {{ tools_namespace }} 
   shell: >
-    oc -n c0cce6-tools get build --selector build=digital-gov-frontend-test -o custom-columns=:status.phase --no-headers | tail -1
+    oc -n {{ tools_namespace }} get build --selector build={{ react_infra_name }}-{{ version }} -o custom-columns=:status.phase --no-headers | tail -1
   register: build_status
   until: (build_status.stdout == "Complete")
   delay: 60

--- a/ansible/tasks/wait_for_build_to_complete_strapi.yaml
+++ b/ansible/tasks/wait_for_build_to_complete_strapi.yaml
@@ -6,3 +6,4 @@
   delay: 60
   retries: 10
   ignore_errors: False
+  

--- a/ansible/tasks/wait_for_build_to_complete_strapi.yaml
+++ b/ansible/tasks/wait_for_build_to_complete_strapi.yaml
@@ -4,5 +4,5 @@
   register: build_status
   until: (build_status.stdout == "Complete")
   delay: 60
-  retries: 5
+  retries: 10
   ignore_errors: False

--- a/ansible/tasks/wait_for_build_to_complete_strapi.yaml
+++ b/ansible/tasks/wait_for_build_to_complete_strapi.yaml
@@ -1,0 +1,8 @@
+- name: Wait for {{  strapi_infra_name }}-{{ version }} build to complete in {{ tools_namespace }} 
+  shell: >
+    oc -n {{ tools_namespace }} get build --selector build={{ strapi_infra_name }}-{{ version }} -o custom-columns=:status.phase --no-headers | tail -1
+  register: build_status
+  until: (build_status.stdout == "Complete")
+  delay: 60
+  retries: 5
+  ignore_errors: False


### PR DESCRIPTION
This prevents the deployment to test and prod of the apps until their builds are complete.
The ansible script checks that the test and prod builds are completed before triggering the deployment.  
The ansible tasks do this by querying the status every minute for 5 (react) and 10 (strapi) times until the status of the latest build is complete.  
This was tested on both strapi and react apps in both test and prod namespaces