### PR TITLE
Healthchecks

### DIFF
--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -70,11 +70,11 @@ objects:
                   path: /
                   port: 4000
                   scheme: HTTP
-                initialDelaySeconds: 240
+                initialDelaySeconds: 300
                 timeoutSeconds: 1
-                periodSeconds: 30
+                periodSeconds: 90
                 successThreshold: 1
-                failureThreshold: 3
+                failureThreshold: 6
           dnsPolicy: ClusterFirst
           restartPolicy: Always
           schedulerName: default-scheduler

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -68,7 +68,7 @@ objects:
               readinessProbe:
                 httpGet:
                   path: /
-                  port: 8080
+                  port: 4000
                   scheme: HTTP
                 initialDelaySeconds: 240
                 timeoutSeconds: 1

--- a/openshift/templates/react-frontend/dc.yaml
+++ b/openshift/templates/react-frontend/dc.yaml
@@ -65,6 +65,16 @@ objects:
                   name: caddyfile-volume
                   readOnly: true
                   subPath: Caddyfile
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 240
+                timeoutSeconds: 1
+                periodSeconds: 30
+                successThreshold: 1
+                failureThreshold: 3
           dnsPolicy: ClusterFirst
           restartPolicy: Always
           schedulerName: default-scheduler

--- a/openshift/templates/strapi/dc.yaml
+++ b/openshift/templates/strapi/dc.yaml
@@ -128,6 +128,16 @@ objects:
               volumeMounts:
               - mountPath: /app/public/uploads
                 name: strapi-media-pv
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 1337
+                  scheme: HTTP
+                initialDelaySeconds: 300
+                timeoutSeconds: 1
+                periodSeconds: 90
+                successThreshold: 1
+                failureThreshold: 6
           dnsPolicy: ClusterFirst
           restartPolicy: Always
           schedulerName: default-scheduler


### PR DESCRIPTION
This adds a health check that makes sure the frontend pod is ready before sending traffic to it.  It waits a minimum of 5 minutes then tries 6 more times with 90 second intervals before erroring out.  It should not take longer than that for a new pod to spin up
