### PR TITLE
Fix line height on headings and update nav menu

### DIFF
--- a/react-frontend/src/components/HostingOptions/__snapshots__/hostingOptions.test.js.snap
+++ b/react-frontend/src/components/HostingOptions/__snapshots__/hostingOptions.test.js.snap
@@ -136,7 +136,7 @@ exports[`renders correctly 1`] = `
           name="containers"
         />
         <h2
-          className="sc-dkYRiW bQcciQ heading"
+          className="sc-dkYRiW khXLVZ heading"
           style={
             Object {
               "paddingTop": "44px",
@@ -146,7 +146,7 @@ exports[`renders correctly 1`] = `
           Containers 
         </h2>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Overview
         </h4>
@@ -154,7 +154,7 @@ exports[`renders correctly 1`] = `
           Containers provide a way for several digital services to share a single operating system. Digital teams can focus their efforts on the service they’re providing rather than installing or maintaining the infrastructure. Containers also support the idea of “infrastructure as code”, which means that a service can increase or decrease the resources it requires based on demand or even launch new instances of itself if something goes wrong.
         </p>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Pros 
         </h4>
@@ -174,7 +174,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Cons 
         </h4>
@@ -196,7 +196,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Recommendation
         </h4>
@@ -205,7 +205,7 @@ exports[`renders correctly 1`] = `
            
         </p>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           How to onboard 
         </h4>
@@ -226,7 +226,7 @@ exports[`renders correctly 1`] = `
           name="virtualServers"
         />
         <h2
-          className="sc-dkYRiW bQcciQ heading"
+          className="sc-dkYRiW khXLVZ heading"
           style={
             Object {
               "paddingTop": "44px",
@@ -236,7 +236,7 @@ exports[`renders correctly 1`] = `
           Virtual servers 
         </h2>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Overview
         </h4>
@@ -244,7 +244,7 @@ exports[`renders correctly 1`] = `
           A virtual server provides a way for several digital services to share a single physical server. Virtual servers are an established hosting option for the B.C. government. They are more expensive than containers and require additional maintenance.
         </p>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Pros 
         </h4>
@@ -260,7 +260,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Cons 
         </h4>
@@ -270,7 +270,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Recommendation
         </h4>
@@ -279,7 +279,7 @@ exports[`renders correctly 1`] = `
            
         </p>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           How to onboard
         </h4>
@@ -332,7 +332,7 @@ exports[`renders correctly 1`] = `
           name="physicalServers"
         />
         <h2
-          className="sc-dkYRiW bQcciQ heading"
+          className="sc-dkYRiW khXLVZ heading"
           style={
             Object {
               "paddingTop": "44px",
@@ -342,7 +342,7 @@ exports[`renders correctly 1`] = `
           Physical servers
         </h2>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Overview
         </h4>
@@ -350,7 +350,7 @@ exports[`renders correctly 1`] = `
           Physical servers represent the oldest hosting option currently available for onboarding for B.C. government teams. When using physical servers, teams need to be mindful that there is significant maintenance overhead.
         </p>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Pros 
         </h4>
@@ -363,7 +363,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Cons 
         </h4>
@@ -376,7 +376,7 @@ exports[`renders correctly 1`] = `
           </li>
         </ul>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           Recommendation
         </h4>
@@ -384,7 +384,7 @@ exports[`renders correctly 1`] = `
           Physical servers are not recommended.
         </p>
         <h4
-          className="sc-uoixf iXvwhy subSubHeading"
+          className="sc-uoixf jxIlar subSubHeading"
         >
           How to onboard
         </h4>

--- a/react-frontend/src/components/Learning/__snapshots__/courses.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/courses.test.js.snap
@@ -12,7 +12,7 @@ exports[`renders snapshot correctly 1`] = `
       className="col-sm-12"
     >
       <h2
-        className="sc-ksdxAp kjTIuv heading"
+        className="sc-ksdxAp eluArm heading"
       >
         Courses
       </h2>

--- a/react-frontend/src/components/Learning/__snapshots__/events.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/events.test.js.snap
@@ -12,7 +12,7 @@ exports[`renders correctly 1`] = `
       className="col-sm-12"
     >
       <h2
-        className="sc-dkYRiW bQcciQ heading"
+        className="sc-dkYRiW khXLVZ heading"
       >
         Events
       </h2>

--- a/react-frontend/src/components/Learning/__snapshots__/learning.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/learning.test.js.snap
@@ -50,7 +50,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12"
       >
         <h2
-          className="sc-gsDJrp hrOaUq heading"
+          className="sc-gsDJrp sEzgf heading"
         >
           Courses
         </h2>
@@ -71,7 +71,7 @@ exports[`renders correctly 1`] = `
         className="col-sm-12"
       >
         <h2
-          className="sc-gsDJrp hrOaUq heading"
+          className="sc-gsDJrp sEzgf heading"
         >
           Events
         </h2>
@@ -104,7 +104,7 @@ exports[`renders correctly 1`] = `
             className="sc-giYgFv elqVuN"
           >
             <h2
-              className="sc-gsDJrp hrOaUq heading"
+              className="sc-gsDJrp sEzgf heading"
             >
               The Exchange Podcast 
               <svg
@@ -159,7 +159,7 @@ exports[`renders correctly 1`] = `
           }
         >
           <h3
-            className="sc-hKwCoD gNpiUY subHeading"
+            className="sc-hKwCoD eBjOip subHeading"
             style={
               Object {
                 "marginBottom": "0",

--- a/react-frontend/src/components/Learning/__snapshots__/podcast.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/podcast.test.js.snap
@@ -16,7 +16,7 @@ exports[`renders snapshot correctly 1`] = `
           className="sc-bYoCmx cCSSon"
         >
           <h2
-            className="sc-hKwCoD hXFUby heading"
+            className="sc-hKwCoD cVkmff heading"
           >
             The Exchange Podcast 
             <svg
@@ -71,7 +71,7 @@ exports[`renders snapshot correctly 1`] = `
         }
       >
         <h3
-          className="sc-jRQAMF eYVVhz subHeading"
+          className="sc-jRQAMF jExREi subHeading"
           style={
             Object {
               "marginBottom": "0",

--- a/react-frontend/src/components/Learning/__snapshots__/podcastBanner.test.js.snap
+++ b/react-frontend/src/components/Learning/__snapshots__/podcastBanner.test.js.snap
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
         className="sc-bYoCmx cCSSon"
       >
         <h2
-          className="sc-hKwCoD hXFUby heading"
+          className="sc-hKwCoD cVkmff heading"
         >
           The Exchange Podcast 
           <svg

--- a/react-frontend/src/components/Nav/navbar.js
+++ b/react-frontend/src/components/Nav/navbar.js
@@ -159,8 +159,21 @@ function NavBar() {
               </NavBarLink>
             </NavBarLi>
             <NavBarLi>
+              <NavBarLinkExternal href="/digital-trust">
+                Digital Trust
+                <FontAwesomeIcon
+                  icon={faExternalLinkAlt}
+                  style={{ paddingLeft: '5px', height: '25px' }}
+                />
+              </NavBarLinkExternal>
+            </NavBarLi>
+            <NavBarLi>
               <NavBarLinkExternal href="/marketplace">
                 Marketplace
+                <FontAwesomeIcon
+                  icon={faExternalLinkAlt}
+                  style={{ paddingLeft: '5px', height: '25px' }}
+                />
               </NavBarLinkExternal>
             </NavBarLi>
           </NavBarUl>

--- a/react-frontend/src/components/StyleComponents/headings.js
+++ b/react-frontend/src/components/StyleComponents/headings.js
@@ -10,7 +10,7 @@ export const Heading = styled.h2.attrs({
 })`
   font-size: 31px;
   font-weight: 700;
-  line-height: 1.6;
+  line-height: 1.3;
 `;
 
 export const FAQHeading = styled.h3.attrs({
@@ -27,7 +27,7 @@ export const SubHeading = styled.h3.attrs({
 })`
   font-size: 26px;
   font-weight: 700;
-  line-height: 1.6;
+  line-height: 1.3;
 `;
 
 export const SubSubHeading = styled.h4.attrs({
@@ -35,7 +35,7 @@ export const SubSubHeading = styled.h4.attrs({
 })`
   font-size: 21.6px;
   font-weight: 700;
-  line-height: 1.6;
+  line-height: 1.3;
 `;
 
 export const CaseStudyHeading = styled(Heading)`


### PR DESCRIPTION
Changes:
- Reduce `line-height` on headings (#853) 
- Add Digital Trust to nav menu and add back external link icon to Digital Trust and Marketplace menu items (#1002)