### PR TITLE
Continous deployment to test

### DIFF
--- a/ansible/create-gh-deployment.yaml
+++ b/ansible/create-gh-deployment.yaml
@@ -35,7 +35,7 @@
             Authorization: token {{ GITHUB_TOKEN }}
             Accept: application/vnd.github.ant-man-preview+json
         register: deployment
-      - name: print to stdout
+      - name: print to std out
         command: echo "{{ deployment.json }}"
         register: hello
 


### PR DESCRIPTION
creating a gh deployment was failing due to the auto merge feature of the deployment API. the API will not create a deployment if an auto merge happens, which causes the task the subsequently fail. This branch was merged first before the pull req - testing to see if it fails.